### PR TITLE
Include package and theme timing data

### DIFF
--- a/lib/collector.coffee
+++ b/lib/collector.coffee
@@ -50,8 +50,18 @@ module.exports =
         'unknown'
 
     # Private
-    getPackageNames: ->
-      _.pluck(atom.getActivePackages(), 'name')
+    getPackageData: ->
+      atom.getLoadedPackages().map (pack) ->
+        name: pack.name
+        loadTime: pack.loadTime
+        activateTime: pack.activateTime
+
+    # Private
+    getThemeData: ->
+      atom.themes.getLoadedThemes().map (theme) ->
+        name: theme.name
+        loadTime: theme.loadTime
+        activateTime: theme.activateTime
 
     # Public: Returns an object containing all data collected.
     getData: (additionalData) ->
@@ -63,5 +73,6 @@ module.exports =
         screen_resolution: @getScreenResolution()
         pixel_ratio: @getPixelRatio()
         browser_resolution: @getBrowserResolution()
-        packages: JSON.stringify(@getPackageNames())
+        packages: JSON.stringify(@getPackageData())
+        themes: JSON.stringify(@getThemeData())
       _.extend(data, additionalData)

--- a/spec/collector-spec.coffee
+++ b/spec/collector-spec.coffee
@@ -21,3 +21,18 @@ describe "Collector", ->
 
       expect(keys).toContain 'packages'
       expect(data.packages).toEqual '[]'
+
+      expect(keys).toContain 'themes'
+      expect(data.packages).toEqual '[]'
+
+    describe "with a package", ->
+      beforeEach ->
+        atom.loadPackage('metrics')
+        atom.activatePackage('metrics')
+
+      it "creates a request with package data", ->
+        data = subject.getData()
+        packages = JSON.parse(data.packages)
+        expect(packages[0].name).toEqual 'metrics'
+        expect(packages[0].loadTime).toBeDefined
+        expect(packages[0].activateTime).toBeDefined


### PR DESCRIPTION
Implements #2, now we will receive `loadTime` and `activationTime` from all packages and themes installed by our users.

I don't have any immediate plans for the data but I'm sure it will be useful as we determine what to optimize in the future.
