### PR TITLE
Add cpu count and total memory

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -1,3 +1,4 @@
+os = require 'os'
 request = require 'request'
 
 module.exports =
@@ -12,6 +13,8 @@ module.exports =
           screen_resolution: screen.width + "x" + screen.height
           pixel_ratio: window.devicePixelRatio
           version: atom.getVersion()
+          cpus: os.cpus()?.length ? 0
+          memory: os.totalmem() ? 0
         context:
           packages: @getPackageData()
           themes: @getThemeData()


### PR DESCRIPTION
With people reporting 'slowness', it would be cool to start collecting the number of cores and total memory on machines running Atom.
