### PR TITLE
Add the user agent reporting

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -61,6 +61,8 @@ module.exports =
       @request
         method: 'POST'
         url: "https://www.google-analytics.com/collect"
+        headers:
+          'User-Agent': navigator.userAgent
         qs: params
 
     # Private


### PR DESCRIPTION
Currently our metrics don't include OS/OS version information. By setting the `user-agent` header, I'm hoping this will work as expected. My only concern is that since our profile is currently set as a mobile application they might disregard desktop UAs. 

Unfortunately you can't see OS in the realtime events, so we have to release this and see if it works as expected.
