### PR TITLE
Use ajax request

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -1,4 +1,4 @@
-https = require 'https'
+{$} = require 'atom'
 path = require 'path'
 querystring = require 'querystring'
 
@@ -54,16 +54,11 @@ module.exports =
     @send: (params) ->
       _.extend(params, @defaultParams())
       @request
-        method: 'POST'
-        hostname: 'www.google-analytics.com'
-        path: "/collect?#{querystring.stringify(params)}"
-        headers:
-          'User-Agent': navigator.userAgent
+        type: 'POST'
+        url: "https://www.google-analytics.com/collect?#{querystring.stringify(params)}"
 
     @request: (options) ->
-      request = https.request(options)
-      request.on 'error', -> # This prevents errors from going to the console
-      request.end()
+      $.ajax(options) if navigator.onLine
 
     @defaultParams: ->
       v: 1

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -26,7 +26,5 @@ describe "Metrics", ->
 
     runs ->
       [requestArgs] = Reporter.request.calls[0].args
-      expect(requestArgs.method).toBe 'POST'
-      expect(requestArgs.hostname).toBe 'www.google-analytics.com'
-      expect(requestArgs.headers).toBeDefined()
-      expect(requestArgs.path).toBeDefined()
+      expect(requestArgs.type).toBe 'POST'
+      expect(requestArgs.url).toBeDefined()


### PR DESCRIPTION
Doing an `https.request` seems to run synchronous code that creates a secure context which appears to take long periods of time on certain machines.

So switch to just use an ajax request which appears to not impact start time at all and check the `navigator.onLine` property before sending to prevent offline errors from showing up in the console

Closes #27
