### PR TITLE
Add weekly cohort in addition to start date

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -48,12 +48,22 @@ module.exports =
       else
         callback crypto.createHash('sha1').update(macAddress, 'utf8').digest('hex')
 
-  createStartDate: ->
-    startDate = new Date
+  getTodaysDate: -> new Date
+
+  createStartDate: (startDate) ->
+    startDate ?= @getTodaysDate()
     year = startDate.getFullYear()
     month = startDate.getMonth() + 1
     date = startDate.getDate()
-    "#{year}#{@zerofill(month, 2)}#{@zerofill(date, 2)}"
+    weekNumber = @getWeekNumber(startDate)
+    "#{year}#{@zerofill(month, 2)}#{@zerofill(date, 2)},#{@zerofill(weekNumber, 3)}"
+
+  getWeekNumber: (date) ->
+    date ?= @getTodaysDate()
+    oneJan = new Date(date.getFullYear(), 0, 1)
+    weekNumber = Math.ceil((((date - oneJan) / 86400000) + oneJan.getDay() + 1) / 7)
+    weekNumber = 101 if weekNumber is 53
+    weekNumber + 100 * (date.getFullYear() - 2014)
 
   zerofill: (value, zeros) ->
     (new Array(zeros + 1).join('0') + value).slice(-zeros)


### PR DESCRIPTION
This should allow us to do the 28 days later, and generally see retention on a week by week basis. 

Format is `yyyymmdd,week#`. Weeks are given a number starting from `1` for jan 1 in 2014. For each year week numbers increment by `100`. So jan 1 2015 is `101`, week 52 in 2015 will be `152`. The GA matchers for using this data are really flexible (regex!), so they should be easy to match either monthly or weekly, depending on our needs.

For example: `20141105,045` for today.
