### PR TITLE
Reduce load and activation time by removing jquery and underscore depend...

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -1,8 +1,16 @@
-$ = require 'jquery'
 path = require 'path'
 querystring = require 'querystring'
 
-_ = require 'underscore-plus'
+extend = (target, propertyMaps...) ->
+  for propertyMap in propertyMaps
+    for key, value of propertyMap
+      target[key] = value
+  target
+
+post = (url) ->
+  xhr = new XMLHttpRequest()
+  xhr.open("POST", url)
+  xhr.send(null)
 
 module.exports =
   class Reporter
@@ -75,20 +83,18 @@ module.exports =
       @send(params)
 
     @send: (params) ->
-      _.extend(params, @defaultParams())
-      @request
-        type: 'POST'
-        url: "https://www.google-analytics.com/collect?#{querystring.stringify(params)}"
+      extend(params, @defaultParams())
+      @request("https://www.google-analytics.com/collect?#{querystring.stringify(params)}")
 
-    @request: (options) ->
-      $.ajax(options) if navigator.onLine
+    @request: (url) ->
+      post(url) if navigator.onLine
 
     @defaultParams: ->
       params = {}
       params.cd1 = startDate if startDate = localStorage.getItem('metrics.sd')
 
       # https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
-      _.extend params,
+      extend params,
         v: 1
         tid: "UA-3769691-33"
         cid: localStorage.getItem('metrics.userId')

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     }
   },
   "dependencies": {
-    "jquery": "^2.0",
     "node-uuid": "~1.4.1",
-    "getmac": "~1.0.0",
-    "underscore-plus": "1.x"
+    "getmac": "~1.0.0"
+  },
+  "devDependencies": {
+    "jquery": "^2.0"
   }
 }

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -37,9 +37,8 @@ describe "Metrics", ->
       Reporter.request.callCount is 3
 
     runs ->
-      [requestArgs] = Reporter.request.calls[0].args
-      expect(requestArgs.type).toBe 'POST'
-      expect(requestArgs.url).toBeDefined()
+      [url] = Reporter.request.calls[0].args
+      expect(url).toBeDefined()
 
   describe "sending commands", ->
     beforeEach ->
@@ -55,17 +54,17 @@ describe "Metrics", ->
       atom.commands.dispatch(workspaceElement, command, null)
       expect(Reporter.commandCount[command]).toBe 1
 
-      [requestArgs] = Reporter.request.mostRecentCall.args
-      expect(requestArgs.url).toContain "ec=command"
-      expect(requestArgs.url).toContain "ea=some-package"
-      expect(requestArgs.url).toContain "el=some-package%3Aa-command"
-      expect(requestArgs.url).toContain "ev=1"
+      [url] = Reporter.request.mostRecentCall.args
+      expect(url).toContain "ec=command"
+      expect(url).toContain "ea=some-package"
+      expect(url).toContain "el=some-package%3Aa-command"
+      expect(url).toContain "ev=1"
 
       atom.commands.dispatch(workspaceElement, command, null)
       expect(Reporter.commandCount[command]).toBe 2
 
-      [requestArgs] = Reporter.request.mostRecentCall.args
-      expect(requestArgs.url).toContain "ev=2"
+      [url] = Reporter.request.mostRecentCall.args
+      expect(url).toContain "ev=2"
 
     it "does not report editor: and core: commands", ->
       Reporter.request.reset()
@@ -107,43 +106,43 @@ describe "Metrics", ->
       message = "Uncaught TypeError: Cannot call method 'getScreenRow' of undefined"
       window.onerror(message, 'abc', 2, 3, {ok: true})
 
-      [requestArgs] = Reporter.request.mostRecentCall.args
-      expect(requestArgs.url).toContain "t=exception"
-      expect(requestArgs.url).toContain "exd=TypeError"
+      [url] = Reporter.request.mostRecentCall.args
+      expect(url).toContain "t=exception"
+      expect(url).toContain "exd=TypeError"
 
     describe "when the message has no clear type", ->
       it "reports an exception with the correct type", ->
         message = ""
         window.onerror(message, 2, 3, {ok: true})
 
-        [requestArgs] = Reporter.request.mostRecentCall.args
-        expect(requestArgs.url).toContain "t=exception"
-        expect(requestArgs.url).toContain "exd=Unknown"
+        [url] = Reporter.request.mostRecentCall.args
+        expect(url).toContain "t=exception"
+        expect(url).toContain "exd=Unknown"
 
     describe "when there are paths in the exception", ->
       it "strips unix paths surrounded in quotes", ->
         message = "Error: ENOENT, unlink '/Users/someguy/path/file.js'"
         window.onerror(message, 2, 3, {ok: true})
-        [requestArgs] = Reporter.request.mostRecentCall.args
-        expect(decodeURIComponent(requestArgs.url)).toContain "exd=Error: ENOENT, unlink <path>"
+        [url] = Reporter.request.mostRecentCall.args
+        expect(decodeURIComponent(url)).toContain "exd=Error: ENOENT, unlink <path>"
 
       it "strips unix paths without quotes", ->
         message = "Uncaught Error: spawn /Users/someguy.omg/path/file-09238_ABC-Final-Final.js ENOENT"
         window.onerror(message, 2, 3, {ok: true})
-        [requestArgs] = Reporter.request.mostRecentCall.args
-        expect(decodeURIComponent(requestArgs.url)).toContain "exd=Error: spawn <path> ENOENT"
+        [url] = Reporter.request.mostRecentCall.args
+        expect(decodeURIComponent(url)).toContain "exd=Error: spawn <path> ENOENT"
 
       it "strips windows paths without quotes", ->
         message = "Uncaught Error: spawn c:\\someguy.omg\\path\\file-09238_ABC-Fin%%$#()al-Final.js ENOENT"
         window.onerror(message, 2, 3, {ok: true})
-        [requestArgs] = Reporter.request.mostRecentCall.args
-        expect(decodeURIComponent(requestArgs.url)).toContain "exd=Error: spawn <path> ENOENT"
+        [url] = Reporter.request.mostRecentCall.args
+        expect(decodeURIComponent(url)).toContain "exd=Error: spawn <path> ENOENT"
 
       it "strips windows paths surrounded in quotes", ->
         message = "Uncaught Error: EACCES 'c:\\someguy.omg\\path\\file-09238_ABC-Fin%%$#()al-Final.js'"
         window.onerror(message, 2, 3, {ok: true})
-        [requestArgs] = Reporter.request.mostRecentCall.args
-        expect(decodeURIComponent(requestArgs.url)).toContain "exd=Error: EACCES <path>"
+        [url] = Reporter.request.mostRecentCall.args
+        expect(decodeURIComponent(url)).toContain "exd=Error: EACCES <path>"
 
   describe "when deactivated", ->
     it "stops reporting pane items", ->


### PR DESCRIPTION
...encies.

These large libraries were used only for `$.ajax()` and `_.extend()`.
Each of these functions has a three-line implementation in CoffeeScript,
so it seemed reasonable to just inline the definitions rather than load
a large, expensive library. I think the timing results justify this.

Previous to this diff, I saw:

* `atom.packages.getLoadedPackage('metrics').loadTime` 36
* `atom.packages.getLoadedPackage('metrics').activateTime` 6

After this diff, I saw:

* `atom.packages.getLoadedPackage('metrics').loadTime` 2
* `atom.packages.getLoadedPackage('metrics').activateTime` 1
