### PR TITLE
Sane Defaults on Reporting:

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -8,14 +8,39 @@ IgnoredCommands =
   'vim-mode:move-right': true
 
 module.exports =
+  config:
+    sendUsageStatistics:
+      description: "Allow Atom to send general, pseudonymized information including file
+        types, commands used, screen size, and various timing information via 
+        Google Analytics."
+      default: false,
+      type: "boolean"
+    sendExceptions:
+      description: "Allow atom to report all unhandled exceptions including error message and 
+        stack trace via Google Analytics."
+      default: true,
+      type: "boolean"
+
   activate: ({sessionLength}) ->
     @ensureUserInfo =>
       @begin(sessionLength)
+      @configErrorSubscription = atom.config.onDidChange 'metrics.sendExceptions', (sendExceptions) =>
+        if sendExceptions.newValue
+          @startErrorSubscription()
+        else
+          @stopErrorSubscription()
+
+      @configUsageSubscription = atom.config.onDidChange 'metrics.sendUsageStatistics', (sendUsageStatistics) =>
+        if sendUsageStatistics.newValue
+          @startUsageSubscription()
+        else
+          @stopUsageSubscription()
 
   deactivate: ->
-    @errorSubscription?.dispose()
-    @paneItemSubscription?.dispose()
-    @commandSubscription?.dispose()
+    @configErrorSubscription?.dispose()
+    @configUsageSubscription?.dispose()
+    @stopErrorSubscription()
+    @stopUsageSubscription()
 
   serialize: ->
     sessionLength: Date.now() - @sessionStart
@@ -25,20 +50,20 @@ module.exports =
     sendTiming: Reporter.sendTiming.bind(Reporter)
     sendException: Reporter.sendException.bind(Reporter)
 
-  begin: (sessionLength) ->
-    @sessionStart = Date.now()
-
-    Reporter.sendEvent('window', 'ended', null, sessionLength) if sessionLength
-    Reporter.sendEvent('window', 'started')
-    @paneItemSubscription = atom.workspace.onDidAddPaneItem ({item}) ->
-      Reporter.sendPaneItem(item)
-
+  startErrorSubscription: ->
     @errorSubscription = atom.onDidThrowError (event) ->
       errorMessage = event
       errorMessage = event.message if typeof event isnt 'string'
       errorMessage = stripPath(errorMessage) or 'Unknown'
       errorMessage = errorMessage.replace('Uncaught ', '').slice(0, 150)
       Reporter.sendException(errorMessage)
+
+  stopErrorSubscription: ->
+    @errorSubscription?.dispose()
+
+  startUsageSubscription: ->
+    @paneItemSubscription = atom.workspace.onDidAddPaneItem ({item}) ->
+      Reporter.sendPaneItem(item)
 
     @commandSubscription = atom.commands.onWillDispatch (commandEvent) ->
       {type: eventName} = commandEvent
@@ -48,6 +73,23 @@ module.exports =
       return if eventName of IgnoredCommands
       Reporter.sendCommand(eventName)
 
+  stopUsageSubscription: ->
+    @paneItemSubscription?.dispose()
+    @commandSubscription?.dispose()
+
+  begin: (sessionLength) ->
+    @sessionStart = Date.now()
+
+    if atom.config.get("metrics.sendExceptions")
+      @startErrorSubscription()
+
+    return unless atom.config.get("metrics.sendUsageStatistics")
+
+    @startUsageSubscription()
+
+    Reporter.sendEvent('window', 'ended', null, sessionLength) if sessionLength
+    Reporter.sendEvent('window', 'started')
+    
     if atom.getLoadSettings().shellLoadTime?
       # Only send shell load time for the first window
       Reporter.sendTiming('shell', 'load', atom.getLoadSettings().shellLoadTime)

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -1,6 +1,11 @@
 $ = require 'jquery'
 Reporter = require '../lib/reporter'
 
+activate = () ->
+  atom.config.set("metrics.sendUsageStatistics", true)
+  atom.config.set("metrics.sendExceptions", true)
+  atom.packages.activatePackage('metrics')
+
 describe "Metrics", ->
   [workspaceElement] = []
   beforeEach ->
@@ -21,7 +26,7 @@ describe "Metrics", ->
 
   it "reports events", ->
     waitsForPromise ->
-      atom.packages.activatePackage('metrics')
+      activate()
 
     waitsFor ->
       Reporter.request.callCount is 2
@@ -31,7 +36,7 @@ describe "Metrics", ->
       atom.packages.deactivatePackage('metrics')
 
     waitsForPromise ->
-      atom.packages.activatePackage('metrics')
+      activate()
 
     waitsFor ->
       Reporter.request.callCount is 3
@@ -43,7 +48,7 @@ describe "Metrics", ->
   describe "sending commands", ->
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage('metrics')
+        activate()
 
       waitsFor ->
         Reporter.request.callCount > 0
@@ -97,7 +102,7 @@ describe "Metrics", ->
       spyOn(atom, 'openDevTools')
       spyOn(atom, 'executeJavaScriptInDevTools')
       waitsForPromise ->
-        atom.packages.activatePackage('metrics')
+        activate()
 
       waitsFor ->
         Reporter.request.callCount > 0
@@ -149,7 +154,7 @@ describe "Metrics", ->
       spyOn(Reporter, 'sendPaneItem')
 
       waitsForPromise ->
-        atom.packages.activatePackage('metrics')
+        activate()
 
       waitsFor ->
         Reporter.request.callCount > 0
@@ -172,7 +177,7 @@ describe "Metrics", ->
     reporterService = null
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage('metrics').then (pack) ->
+        activate().then (pack) ->
           reporterService = pack.mainModule.provideReporter()
 
       waitsFor ->


### PR DESCRIPTION
Changes metrics to only send exceptions by default.  Adds two config options to the metrics package to toggle sending exceptions/other info.

See #25, atom/atom#5045, atom/atom#4966, #16, #38, atom/atom#5669