### PR TITLE
Track deprecation message

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -102,7 +102,7 @@ module.exports =
 
           unless @deprecationCache[nameAndVersion + message]?
             @deprecationCache[nameAndVersion + message] = true
-            Reporter.sendEvent('deprecation', nameAndVersion, message)
+            Reporter.sendEvent('deprecation-v2', nameAndVersion, message)
 
         return
 

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -166,8 +166,8 @@ describe "Metrics", ->
         [url] = Reporter.request.mostRecentCall.args
         expect(url).toContain "t=event"
         expect(url).toContain "ec=deprecation"
-        expect(url).toContain "ea=somepackage"
-        expect(url).toContain "el=unknown"
+        expect(url).toContain "ea=somepackage%40unknown"
+        expect(url).toContain "el=bad%20things%20are%20bad"
 
     it "reports a deprecation without metadata specified", ->
       Reporter.request.reset()
@@ -202,8 +202,8 @@ describe "Metrics", ->
         [url] = Reporter.request.mostRecentCall.args
         expect(url).toContain "t=event"
         expect(url).toContain "ec=deprecation"
-        expect(url).toContain "ea=metrics"
-        expect(url).toMatch "el=[0-9]+\.[0-9]+\.[0-9]+"
+        expect(url).toMatch "ea=metrics%40[0-9]+\.[0-9]+\.[0-9]+"
+        expect(url).toContain "el=bad%20things%20are%20bad"
 
   describe "when deactivated", ->
     it "stops reporting pane items", ->

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -176,9 +176,13 @@ describe "Metrics", ->
       stack = [
         {
           fileName: '/Applications/Atom.app/pathwatcher.js'
+          functionName: 'foo'
+          location: '/Applications/Atom.app/pathwatcher.js:10:5'
         }
         {
           fileName: '/Users/me/.atom/packages/metrics/lib/metrics.js'
+          functionName: 'bar'
+          location: '/Users/me/.atom/packages/metrics/lib/metrics.js:161:5'
         }
       ]
       deprecation =

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -176,13 +176,9 @@ describe "Metrics", ->
       stack = [
         {
           fileName: '/Applications/Atom.app/pathwatcher.js'
-          functionName: 'foo'
-          location: '/Applications/Atom.app/pathwatcher.js:10:5'
         }
         {
           fileName: '/Users/me/.atom/packages/metrics/lib/metrics.js'
-          functionName: 'bar'
-          location: '/Users/me/.atom/packages/metrics/lib/metrics.js:161:5'
         }
       ]
       deprecation =


### PR DESCRIPTION
Track deprecation messages so we know what the most common deprecations are. Additionally, this:

* Removes unnecessary extra deprecation reporting. Deprecations for each package / version / message combo will only be reported once.
* Speeds up reporting by not running the stack parser.