### PR TITLE
Track release channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Metrics package.
 * The amount of time the current window was open for
 * The amount of time the current window took to load
 * The amount of time the app took to launch
+* The app's release channel (stable, beta, dev)
 * Deprecations: package name and version of each deprecation
 
 [GA]: http://www.google.com/analytics

--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -12,6 +12,15 @@ post = (url) ->
   xhr.open("POST", url)
   xhr.send(null)
 
+getReleaseChannel = ->
+  version = atom.getVersion()
+  if version.indexOf('beta') > -1
+    'beta'
+  else if version.indexOf('dev') > -1
+    'dev'
+  else
+    'stable'
+
 module.exports =
   class Reporter
     @sendEvent: (category, action, label, value) ->
@@ -101,3 +110,4 @@ module.exports =
         an: 'atom'
         av: atom.getVersion()
         sr: "#{screen.width}x#{screen.height}"
+        aiid: getReleaseChannel()

--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -41,6 +41,46 @@ describe "Metrics", ->
       [url] = Reporter.request.calls[0].args
       expect(url).toBeDefined()
 
+  describe "reporting release channel", ->
+    beforeEach ->
+      localStorage.setItem('metrics.userId', 'a')
+
+    it "reports the dev release channel", ->
+      spyOn(atom, 'getVersion').andReturn '1.0.2-dev-dedbeef'
+      waitsForPromise ->
+        atom.packages.activatePackage('metrics')
+
+      waitsFor ->
+        Reporter.request.callCount > 0
+
+      runs ->
+        [url] = Reporter.request.mostRecentCall.args
+        expect(url).toContain "aiid=dev"
+
+    it "reports the beta release channel", ->
+      spyOn(atom, 'getVersion').andReturn '1.0.2-beta1'
+      waitsForPromise ->
+        atom.packages.activatePackage('metrics')
+
+      waitsFor ->
+        Reporter.request.callCount > 0
+
+      runs ->
+        [url] = Reporter.request.mostRecentCall.args
+        expect(url).toContain "aiid=beta"
+
+    it "reports the stable release channel", ->
+      spyOn(atom, 'getVersion').andReturn '1.0.2'
+      waitsForPromise ->
+        atom.packages.activatePackage('metrics')
+
+      waitsFor ->
+        Reporter.request.callCount > 0
+
+      runs ->
+        [url] = Reporter.request.mostRecentCall.args
+        expect(url).toContain "aiid=stable"
+
   describe "reporting commands", ->
     describe "when the user is NOT chosen to send commands", ->
       beforeEach ->


### PR DESCRIPTION
We currently do not know how many users are on each release channel. This will allows us to see the breakdown of stable / beta / dev users.