### PR TITLE
Return a promise when mocking ::openDevTools

### DIFF
--- a/spec/metrics-spec.coffee
+++ b/spec/metrics-spec.coffee
@@ -162,7 +162,7 @@ describe "Metrics", ->
 
   describe "reporting exceptions", ->
     beforeEach ->
-      spyOn(atom, 'openDevTools')
+      spyOn(atom, 'openDevTools').andReturn(Promise.resolve())
       spyOn(atom, 'executeJavaScriptInDevTools')
       waitsForPromise ->
         atom.packages.activatePackage('metrics')


### PR DESCRIPTION
This fixes the red build on https://github.com/atom/atom/pull/9788 by conforming to the new `AtomEnvironment::openDevTools` interface.