### PR TITLE
Report package load times

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -52,6 +52,7 @@ module.exports =
     @watchPaneItems()
     @watchCommands()
     @watchDeprecations()
+    @watchActivationTimes()
 
     if atom.getLoadSettings().shellLoadTime?
       # Only send shell load time for the first window
@@ -94,6 +95,17 @@ module.exports =
       return unless eventName.indexOf(':') > -1
       return if eventName of IgnoredCommands
       Reporter.sendCommand(eventName)
+
+  watchActivationTimes: ->
+    atom.packages.onDidActivateInitialPackages ->
+      packages = atom.packages.getLoadedPackages()
+      for pack in packages
+        continue unless pack?.name?
+        continue unless pack?.metadata?.version
+        nameAndVersion = "#{pack.name}-#{pack?.metadata?.version}"
+        activationTime = pack['activateTime']
+
+        Reporter.sendTiming('packageLoadTime', nameAndVersion, activationTime)
 
   watchDeprecations: ->
     @deprecationCache = {}


### PR DESCRIPTION
Verified using a console.log() message before sending the timings in the
watchActivationTimes() function to verify we're sending the right
parameters there.

Sending the timings takes 50ms-100ms on my system, measured using
new Date().getTime() before and after the reporting loop and printing
the time difference using console.log().

Fixes #70