### PR TITLE
Use process.platform instead of process.os

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -23,7 +23,7 @@ getReleaseChannel = ->
 
 getOsArch = ->
   # 32-bit node.exe's os.arch() returns 'x86' on 64-Windows
-  return 'x64' if process.os is 'win32' and process.env.PROCESSOR_ARCHITECTURE is 'AMD64'
+  return 'x64' if process.platform is 'win32' and process.env.PROCESSOR_ARCHITECTURE is 'AMD64'
   return process.arch
 
 module.exports =


### PR DESCRIPTION
The latter doesn't exist.

/cc @damieng 