### PR TITLE
Report total packages load and activation times

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -52,6 +52,7 @@ module.exports =
     @watchPaneItems()
     @watchCommands()
     @watchDeprecations()
+    @watchPackages()
 
     if atom.getLoadSettings().shellLoadTime?
       # Only send shell load time for the first window
@@ -94,6 +95,21 @@ module.exports =
       return unless eventName.indexOf(':') > -1
       return if eventName of IgnoredCommands
       Reporter.sendCommand(eventName)
+
+  watchPackages: ->
+    atom.packages.onDidActivateInitialPackages ->
+      packages = atom.packages.getLoadedPackages()
+      loadTime = 0
+      activateTime = 0
+      for pack in packages
+        t = pack['loadTime']
+        loadTime += t if t?
+
+        t = pack['activateTime']
+        activateTime += t if t?
+
+      Reporter.sendTiming('packages', 'loadTime', loadTime)
+      Reporter.sendTiming('packages', 'activateTime', activateTime)
 
   watchDeprecations: ->
     @deprecationCache = {}


### PR DESCRIPTION
This reports a sum of how long it took for Atom to load all packages
and how long to activate them.

The point is that this can be used to track if / how much of a problem
package load times are for users, and how these times develop over time.

I have tested this by adding console.log() output before the
sendTiming() lines and verified that the reported numbers are close
to what TimeCop says.