### PR TITLE
Make sure itemPath exists before passing it to path.dirname

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -62,7 +62,7 @@ module.exports =
       name = item.getViewClass?().name ? item.constructor.name
       itemPath = item.getPath?()
 
-      return name unless path.dirname(itemPath) is atom.getConfigDirPath()
+      return name unless itemPath? and path.dirname(itemPath) is atom.getConfigDirPath()
 
       extension = path.extname(itemPath)
       switch path.basename(itemPath, extension)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Makes sure that `itemPath` exists before attempting to find its dirname, as dirname arguments must be strings.

### Alternate Designs

A stricter check would be to ensure the itemPath is of type string before passing it in, but I think it's safe to assume that `item.getPath()` will return a string.

### Benefits

No more deprecation notice.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #76

I can add a spec for this if necessary.