### PR TITLE
Fix override of random reporting decision in tests

### DIFF
--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -14,7 +14,7 @@ IgnoredCommands =
 module.exports =
   activate: ({sessionLength}) ->
     @subscriptions = new CompositeDisposable
-    @shouldIncludePanesAndCommands = Reporter.shouldReportPanesAndCommands()
+    @shouldIncludePanesAndCommands = Math.random() < 0.05
     @ensureClientId => @begin(sessionLength)
 
   deactivate: ->

--- a/lib/metrics.coffee
+++ b/lib/metrics.coffee
@@ -14,13 +14,8 @@ IgnoredCommands =
 module.exports =
   activate: ({sessionLength}) ->
     @subscriptions = new CompositeDisposable
-    overridePanesAndCommands = localStorage.getItem('metrics.panesAndCommands')
-    if (overridePanesAndCommands)
-      @shouldIncludePanesAndCommands = overridePanesAndCommands
-    else
-      @shouldIncludePanesAndCommands = Math.random() < 0.05
-    @ensureClientId =>
-      @begin(sessionLength)
+    @shouldIncludePanesAndCommands = Reporter.shouldReportPanesAndCommands()
+    @ensureClientId => @begin(sessionLength)
 
   deactivate: ->
     @subscriptions?.dispose()

--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -28,8 +28,6 @@ getOsArch = ->
 
 module.exports =
   class Reporter
-    @shouldReportPanesAndCommands: -> Math.random() < 0.05
-
     @consented: ->
       atom.config.get('core.telemetryConsent') is 'limited'
 

--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -28,6 +28,8 @@ getOsArch = ->
 
 module.exports =
   class Reporter
+    @shouldReportPanesAndCommands: -> Math.random() < 0.05
+
     @consented: ->
       atom.config.get('core.telemetryConsent') is 'limited'
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -144,6 +144,7 @@ describe("Metrics", async () => {
     describe("when the user is chosen to send commands", async () => {
       beforeEach(async () => {
         localStorage.setItem('metrics.userId', 'd')
+        spyOn(Reporter, 'shouldReportPanesAndCommands').andReturn(true)
 
         await atom.packages.activatePackage('metrics')
 
@@ -323,7 +324,7 @@ describe("Metrics", async () => {
     describe("when the user is NOT chosen to send events", async () => {
       beforeEach(async () => {
         localStorage.setItem('metrics.userId', 'a')
-        localStorage.setItem('metrics.panesAndCommands', false)
+        spyOn(Reporter, 'shouldReportPanesAndCommands').andReturn(false)
         spyOn(Reporter, 'sendPaneItem')
 
         await atom.packages.activatePackage('metrics')
@@ -341,7 +342,7 @@ describe("Metrics", async () => {
     describe("when the user IS chosen to send events", async () => {
       beforeEach(async () => {
         localStorage.setItem('metrics.userId', 'd')
-        localStorage.setItem('metrics.panesAndCommands', true)
+        spyOn(Reporter, 'shouldReportPanesAndCommands').andReturn(true)
         spyOn(Reporter, 'sendPaneItem')
 
         await atom.packages.activatePackage('metrics')

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -129,8 +129,8 @@ describe("Metrics", async () => {
         await atom.packages.activatePackage('metrics')
         await conditionPromise(() => Reporter.request.callCount > 0)
 
-        let Metrics = atom.packages.getLoadedPackage('metrics').mainModule
-        Metrics.shouldIncludePanesAndCommands = false
+        const {mainModule} = atom.packages.getLoadedPackage('metrics')
+        mainModule.shouldIncludePanesAndCommands = false
       })
 
       it("does not watch for commands", async () => {
@@ -144,12 +144,10 @@ describe("Metrics", async () => {
     describe("when the user is chosen to send commands", async () => {
       beforeEach(async () => {
         localStorage.setItem('metrics.userId', 'd')
-        spyOn(Reporter, 'shouldReportPanesAndCommands').andReturn(true)
-
         await atom.packages.activatePackage('metrics')
 
-        let Metrics = atom.packages.getLoadedPackage('metrics').mainModule
-        Metrics.shouldIncludePanesAndCommands = true
+        const {mainModule} = atom.packages.getLoadedPackage('metrics')
+        mainModule.shouldIncludePanesAndCommands = true
       })
 
       it("reports commands dispatched via atom.commands", () => {
@@ -324,10 +322,10 @@ describe("Metrics", async () => {
     describe("when the user is NOT chosen to send events", async () => {
       beforeEach(async () => {
         localStorage.setItem('metrics.userId', 'a')
-        spyOn(Reporter, 'shouldReportPanesAndCommands').andReturn(false)
         spyOn(Reporter, 'sendPaneItem')
 
-        await atom.packages.activatePackage('metrics')
+        const {mainModule} = await atom.packages.activatePackage('metrics')
+        mainModule.shouldIncludePanesAndCommands = false
 
         await conditionPromise(() => Reporter.request.callCount > 0)
       })
@@ -342,10 +340,11 @@ describe("Metrics", async () => {
     describe("when the user IS chosen to send events", async () => {
       beforeEach(async () => {
         localStorage.setItem('metrics.userId', 'd')
-        spyOn(Reporter, 'shouldReportPanesAndCommands').andReturn(true)
         spyOn(Reporter, 'sendPaneItem')
 
-        await atom.packages.activatePackage('metrics')
+        const {mainModule} = await atom.packages.activatePackage('metrics')
+        mainModule.shouldIncludePanesAndCommands = true
+
         await conditionPromise(() => Reporter.request.callCount > 0)
       })
 
@@ -362,10 +361,8 @@ describe("Metrics", async () => {
       localStorage.setItem('metrics.userId', 'd')
       spyOn(Reporter, 'sendPaneItem')
 
-      await atom.packages.activatePackage('metrics')
-
-      let Metrics = atom.packages.getLoadedPackage('metrics').mainModule
-      Metrics.shouldIncludePanesAndCommands = true
+      const {mainModule} = await atom.packages.activatePackage('metrics')
+      mainModule.shouldIncludePanesAndCommands = true
       await conditionPromise(() => Reporter.request.callCount > 0)
 
       await atom.workspace.open('file1.txt')


### PR DESCRIPTION
We have been seeing intermittent failures in this test suite:

https://circleci.com/gh/atom/atom/2647

```
Metrics
  reporting pane items
    when the user is NOT chosen to send events
      it will not report pane items
        Expected 1 to be 0.
          Error: Expected 1 to be 0.
          at /Users/distiller/atom/node_modules/metrics/spec/metrics-spec.js:337:49
          at next (<anonymous>)
          at step (/Users/distiller/atom/node_modules/metrics/spec/metrics-spec.js:3:273)
          at process._tickCallback (internal/process/next_tick.js:103:7)
```

Previously, in order to override the package's random decision as to whether to report the user's panes and commands, the tests would set a special local-storage key called `metrics.panesAndCommands`. But there was a bug in the implementation that caused it to not respect the override properly:

```coffee
if (overridePanesAndCommands)
  @shouldIncludePanesAndCommands = overridePanesAndCommands
else
  @shouldIncludePanesAndCommands = Math.random() < 0.05
```

If the override was set to `false`, we'd simply evaluate the `else` case, causing the tests to fail 5 percent of the time.

/cc @damieng