### PR TITLE
Add metric to help assess awareness of package ecosystem

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -64,6 +64,7 @@ module.exports = {
       }
     }))
 
+    this.watchActivationOfOptionalPackages()
     this.watchPaneItems()
     this.watchCommands()
     this.watchDeprecations()
@@ -101,6 +102,21 @@ module.exports = {
 
   getClientId () {
     return global.localStorage.getItem('metrics.userId')
+  },
+
+  watchActivationOfOptionalPackages () {
+    this.subscriptions.add(atom.packages.onDidActivateInitialPackages(() => {
+      const optionalPackages = atom.packages.getActivePackages().filter((pack) => {
+        return !atom.packages.isBundledPackage(pack.name)
+      })
+
+      Reporter.sendEvent(
+        'package',
+        'numberOptionalPackagesActivatedAtStartup',
+        null,
+        optionalPackages.length
+      )
+    }))
   },
 
   watchPaneItems () {

--- a/spec/fixtures/packages/example/lib/example.js
+++ b/spec/fixtures/packages/example/lib/example.js
@@ -1,0 +1,3 @@
+module.exports = {
+  activate () {}
+}

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -372,10 +372,10 @@ describe('Metrics', async () => {
         await conditionPromise(() => {
           return Reporter.request.calls.find((call) => {
             const url = call.args[0]
-            return url.includes('t=event')
-              && url.includes('ec=package')
-              && url.includes('ea=numberOptionalPackagesActivatedAtStartup')
-              && url.includes('ev=1')
+            return url.includes('t=event') &&
+              url.includes('ec=package') &&
+              url.includes('ea=numberOptionalPackagesActivatedAtStartup') &&
+              url.includes('ev=1')
           })
         })
       })
@@ -394,10 +394,10 @@ describe('Metrics', async () => {
         await conditionPromise(() => {
           return Reporter.request.calls.find((call) => {
             const url = call.args[0]
-            return url.includes('t=event')
-              && url.includes('ec=package')
-              && url.includes('ea=numberOptionalPackagesActivatedAtStartup')
-              && url.includes('ev=0')
+            return url.includes('t=event') &&
+              url.includes('ec=package') &&
+              url.includes('ea=numberOptionalPackagesActivatedAtStartup') &&
+              url.includes('ev=0')
           })
         })
       })

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -3,6 +3,7 @@
 import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
 import Reporter from '../lib/reporter'
 import grim from 'grim'
+import path from 'path'
 
 describe('Metrics', async () => {
   let workspaceElement = []
@@ -357,6 +358,13 @@ describe('Metrics', async () => {
 
   describe('reporting activation of optional packages', async () => {
     describe('when optional packages are present', () => {
+      let originalPackageDirPaths = atom.packages.packageDirPaths
+
+      beforeEach(() => {
+        const packageFixturePath = path.join(__dirname, 'fixtures', 'packages')
+        atom.packages.packageDirPaths.push(packageFixturePath)
+      })
+
       it('reports the number of optional packages activated at startup', async () => {
         await atom.packages.activatePackage('metrics')
         expect(atom.packages.isBundledPackage('metrics')).toBe(true)
@@ -378,6 +386,10 @@ describe('Metrics', async () => {
               url.includes('ev=1')
           })
         })
+      })
+
+      afterEach(() => {
+        atom.packages.packageDirPaths = originalPackageDirPaths
       })
     })
 


### PR DESCRIPTION
### Description of the Change

We consider Atom's extensibility (or "hackability!" 😁) to be one of its most important features. That extensibility comes in [multiple forms](https://flight-manual.atom.io/hacking-atom/), but for many users, the [package ecosystem](https://atom.io/packages) will be the primary means of extensibility. Atom's [welcome guide](https://github.com/atom/welcome) promotes the package ecosystem, but we don't currently have a way of knowing whether that translates into users actually installing packages. To assess the awareness and approachability of the package ecosystem, this pull request adds a metric to report the number of packages that a user has installed.

Equipped with this information, we'll be able to assess the effectiveness of our efforts to increase the awareness and approachability of the package ecosystem. For example, does a particular tweak to the welcome guide increase or decrease the percentage of users that have installed a package? Similarly, if we were to add an "Install" button on each package page on https://atom.io, does that result in an increase in the percentage of users that have installed a package?

Implementation-wise, this pull request sends an event that reports the quantity of optional (i.e., non-bundled) packages that get activated at Atom startup.

### Alternate Designs

Instead of sending the _count_ of optional packages that are activated, it would provide richer information if we sent the _names_ of the optional packages that are activated. However, I don't think it will be practical to take that approach:
- Our [analytics system](https://developers.google.com/analytics/devguides/collection/analyticsjs/) doesn't currently support metrics that specific a _list_ (or array) of data, so we can't report a single metric that includes the list of packages. (I suppose we could send a string of package names separated by some delimiter, but ... yuck.)
- To get around that limitation, we could report an event for each package that gets activated and we could include the name of the activated package. However, that would likely result in many more network requests (since our [analytics library](https://developers.google.com/analytics/devguides/collection/analyticsjs/) makes an HTTP request for each event being reported), _and_ we'd likely exceed the [rate limit](https://developers.google.com/analytics/devguides/collection/analyticsjs/limits-quotas#analyticsjs), causing some metrics to get dropped.

### Verification Process

- [x] Using an Atom installation that only has Atom's bundled packages, verify that an event is recorded at startup reflecting that the instance has zero optional packages
- [x] Using an Atom installation that has optional packages installed, verify that an event is recorded at startup reflecting the number of optional packages
