### PR TITLE
Report arbitrary release channel names

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -21,7 +21,7 @@ const getReleaseChannel = function () {
   const version = atom.getVersion()
   const match = version.match(/\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/)
   if (!match) {
-    return 'unknown'
+    return 'unrecognized'
   } else if (match[2]) {
     return match[2]
   }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -19,13 +19,15 @@ const post = function (url) {
 
 const getReleaseChannel = function () {
   const version = atom.getVersion()
-  if (version.indexOf('beta') > -1) {
-    return 'beta'
-  } else if (version.indexOf('dev') > -1) {
-    return 'dev'
-  } else {
-    return 'stable'
+  const match = version.match(/\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/)
+  if (!match) {
+    return 'unknown'
   }
+  else if (match[2]) {
+    return match[2]
+  }
+
+  return 'stable'
 }
 
 const getOsArch = function () {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -22,8 +22,7 @@ const getReleaseChannel = function () {
   const match = version.match(/\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/)
   if (!match) {
     return 'unknown'
-  }
-  else if (match[2]) {
+  } else if (match[2]) {
     return match[2]
   }
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -122,6 +122,16 @@ describe('Metrics', async () => {
       expect(url).toContain('aiid=stable')
     })
 
+    it('reports the nightly release channel', async () => {
+      spyOn(atom, 'getVersion').andReturn('1.0.2-nightly55')
+
+      await atom.packages.activatePackage('metrics')
+      await conditionPromise(() => Reporter.request.callCount > 0)
+
+      let url = Reporter.request.mostRecentCall.args[0]
+      expect(url).toContain('aiid=nightly')
+    })
+
     it('reports an arbitrary release channel', async () => {
       spyOn(atom, 'getVersion').andReturn('1.0.2-sushi1')
 
@@ -132,14 +142,14 @@ describe('Metrics', async () => {
       expect(url).toContain('aiid=sushi')
     })
 
-    it('reports an unknown release channel', async () => {
+    it('reports an unrecognized release channel', async () => {
       spyOn(atom, 'getVersion').andReturn('wat.0.2')
 
       await atom.packages.activatePackage('metrics')
       await conditionPromise(() => Reporter.request.callCount > 0)
 
       let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=unknown')
+      expect(url).toContain('aiid=unrecognized')
     })
   })
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -121,6 +121,26 @@ describe('Metrics', async () => {
       let url = Reporter.request.mostRecentCall.args[0]
       expect(url).toContain('aiid=stable')
     })
+
+    it('reports an arbitrary release channel', async () => {
+      spyOn(atom, 'getVersion').andReturn('1.0.2-sushi1')
+
+      await atom.packages.activatePackage('metrics')
+      await conditionPromise(() => Reporter.request.callCount > 0)
+
+      let url = Reporter.request.mostRecentCall.args[0]
+      expect(url).toContain('aiid=sushi')
+    })
+
+    it('reports an unknown release channel', async () => {
+      spyOn(atom, 'getVersion').andReturn('wat.0.2')
+
+      await atom.packages.activatePackage('metrics')
+      await conditionPromise(() => Reporter.request.callCount > 0)
+
+      let url = Reporter.request.mostRecentCall.args[0]
+      expect(url).toContain('aiid=unknown')
+    })
   })
 
   describe('reporting commands', async () => {


### PR DESCRIPTION
### Description of the Change

This change updates the release channel reporting logic to support arbitrary channel names by comparing the current Atom version against a regular expression.  This will enable the new Atom Nightly release channel to be reported.

### Alternate Designs

A simpler solution would just be to look for `nightly` in the Atom version just as we do for `beta`, but this solution gives us the flexibility to have other release channels in the future with less effort.

### Benefits

We'll have usage metrics for other release channels!

### Possible Drawbacks

None that I can think of.

### Applicable Issues

https://github.com/atom/atom/pull/17538
