### PR TITLE
fix snapshotting

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -4,7 +4,6 @@ const path = require('path')
 const Reporter = require('./reporter')
 const fs = require('fs-plus')
 const grim = require('grim')
-const store = require('./store')
 
 const IgnoredCommands = {
   'vim-mode:move-up': true,
@@ -68,7 +67,7 @@ module.exports = {
       }
 
       const notOptedIn = newValue !== 'limited'
-      store.setOptOut(notOptedIn)
+      Reporter.getStore().setOptOut(notOptedIn)
     }))
 
     this.watchActivationOfOptionalPackages()

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const querystring = require('querystring')
-const store = require('./store')
+const telemetry = require('telemetry-github')
 
 const extend = function (target, ...propertyMaps) {
   for (let propertyMap of propertyMaps) {
@@ -37,20 +37,22 @@ const getOsArch = function () {
   return process.arch
 }
 
+let store;
+
 module.exports =
 class Reporter {
   static incrementCounter (counterName) {
-    store.incrementCounter(counterName)
+    this.getStore().incrementCounter(counterName)
   }
 
   static addCustomEvent (eventType, event) {
     extend(event, this.getEventMetadata())
-    store.addCustomEvent(eventType, event)
+    this.getStore().addCustomEvent(eventType, event)
   }
 
   static addTiming (eventType, durationInMilliseconds, metadata = {}) {
     extend(metadata, this.getEventMetadata())
-    store.addTiming(eventType, durationInMilliseconds, metadata)
+    this.getStore().addTiming(eventType, durationInMilliseconds, metadata)
   }
 
   // Deprecated: use addCustomEvent instead.
@@ -122,6 +124,16 @@ class Reporter {
 
     this.addCustomEvent(eventType, params)
     this.send(params)
+  }
+
+  // Private
+  static getStore () {
+    if (!store) {
+      store = new telemetry.StatsStore('atom', atom.getVersion(), atom.inDevMode())
+      const notOptedIn = atom.config.get('core.telemetryConsent') !== 'limited'
+      store.setOptOut(notOptedIn)
+    }
+    return store;
   }
 
   // Private
@@ -202,3 +214,5 @@ class Reporter {
     return name
   }
 }
+
+module.exports.store = store;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -37,7 +37,7 @@ const getOsArch = function () {
   return process.arch
 }
 
-let store;
+let store
 
 module.exports =
 class Reporter {
@@ -133,7 +133,7 @@ class Reporter {
       const notOptedIn = atom.config.get('core.telemetryConsent') !== 'limited'
       store.setOptOut(notOptedIn)
     }
-    return store;
+    return store
   }
 
   // Private
@@ -214,5 +214,3 @@ class Reporter {
     return name
   }
 }
-
-module.exports.store = store;

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,7 +1,0 @@
-const telemetry = require('telemetry-github')
-
-const store = new telemetry.StatsStore('atom', atom.getVersion(), atom.inDevMode())
-const notOptedIn = atom.config.get('core.telemetryConsent') !== 'limited'
-store.setOptOut(notOptedIn)
-
-module.exports = store

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -2,7 +2,7 @@
 
 import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
 import Reporter from '../lib/reporter'
-import store from '../lib/store'
+import store from '../lib/reporter'
 import grim from 'grim'
 import path from 'path'
 
@@ -20,6 +20,7 @@ describe('Metrics', async () => {
 
     spyOn(Reporter, 'request')
     spyOn(Reporter, 'addCustomEvent').andCallThrough()
+    spyOn(Reporter, 'getStore').andCallThrough()
 
     let storage = {}
     spyOn(global.localStorage, 'setItem').andCallFake((key, value) => { storage[key] = value })

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -2,9 +2,12 @@
 
 import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './helpers/async-spec-helpers' // eslint-disable-line no-unused-vars
 import Reporter from '../lib/reporter'
-import store from '../lib/reporter'
 import grim from 'grim'
 import path from 'path'
+
+const telemetry = require('telemetry-github')
+
+const store = new telemetry.StatsStore('atom', '1.2.3', true)
 
 describe('Metrics', async () => {
   let workspaceElement = []
@@ -20,7 +23,7 @@ describe('Metrics', async () => {
 
     spyOn(Reporter, 'request')
     spyOn(Reporter, 'addCustomEvent').andCallThrough()
-    spyOn(Reporter, 'getStore').andCallThrough()
+    spyOn(Reporter, 'getStore').andCallFake(() => store)
 
     let storage = {}
     spyOn(global.localStorage, 'setItem').andCallFake((key, value) => { storage[key] = value })


### PR DESCRIPTION
When I tried to bump the `metrics` version in `atom/atom` to `1.4.0`, snapshotting tests failed with the following error:

```
ReferenceError: atom is not defined
    at Object.../node_modules/metrics/lib/store.js (/Users/distiller/atom/out/startup.js:55678:54)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.../node_modules/metrics/lib/reporter.js (/Users/distiller/atom/out/startup.js:55351:21)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.../node_modules/metrics/lib/metrics.js (/Users/distiller/atom/out/startup.js:15056:24)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at Object.<anonymous> (/Users/distiller/atom/out/startup.js:158:11)
    at Object.../src/initialize-application-window.js (/Users/distiller/atom/out/startup.js:235:10)
    at customRequire (/Users/distiller/atom/out/startup.js:94:47)
    at generateSnapshot (/Users/distiller/atom/out/startup.js:351619:3)
Error: Command failed: /Users/distiller/atom/out/Atom.app/Contents/MacOS/Atom /Users/distiller/atom/script/verify-snapshot-script /Users/distiller/atom/out/startup.js
/Users/distiller/atom/out/startup.js:55678
      const store = new telemetry.StatsStore('atom', atom.getVersion(), atom.inDevMode())
```

In order to fix this, I need to defer creating the `StatsStore` until `atom` has been defined.  The approach I took here was to have a wrapper function that memoizes instantiating `StatsStore`. This function isn't called until we try to do something to the store, at which time `atom` will exist.

This approach requires less fiddling to make the tests work than some of the other approaches I considered (such as making `store` a property of the `Reporter` class, which would have required an amount of spying on `Reporter.prototype.someMethod`).

...alternately, I could have blocked the files from the metrics package from being included in snapshot tests but that felt hacky to me.

Test plan:
- [x] run all the unit tests
- [x] Manually call `Reporter.getStore().reportStats()` and verify that stats are sent to Central as they should be.

I wish there was a better way to verify that this fixes the snapshot issue before merging...

![bitmoji](https://render.bitstrips.com/v2/cpanel/b8943fe1-f763-4c60-a1b9-57b91e77d489-f14a1e1d-64bc-41f2-8006-01b6c63adbd8-v1.png?transparent=1&palette=1&width=246)