### PR TITLE
Add metric to help assess awareness of key binding customizability

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -71,6 +71,7 @@ module.exports = {
     }))
 
     this.watchActivationOfOptionalPackages()
+    this.watchLoadingOfUserDefinedKeyBindings()
     this.watchPaneItems()
     this.watchCommands()
     this.watchDeprecations()
@@ -121,6 +122,21 @@ module.exports = {
         'numberOptionalPackagesActivatedAtStartup',
         null,
         optionalPackages.length
+      )
+    }))
+  },
+
+  watchLoadingOfUserDefinedKeyBindings () {
+    this.subscriptions.add(atom.keymaps.onDidLoadUserKeymap(() => {
+      const userDefinedKeyBindings = atom.keymaps.getKeyBindings().filter((binding) => {
+        return binding.source === atom.keymaps.getUserKeymapPath()
+      })
+
+      Reporter.sendEvent(
+        'key-binding',
+        'numberUserDefinedKeyBindingsLoadedAtStartup',
+        null,
+        userDefinedKeyBindings.length
       )
     }))
   },

--- a/spec/fixtures/keymaps/custom-keymap.cson
+++ b/spec/fixtures/keymaps/custom-keymap.cson
@@ -1,0 +1,39 @@
+# Your keymap
+#
+# Atom keymaps work similarly to style sheets. Just as style sheets use
+# selectors to apply styles to elements, Atom keymaps use selectors to associate
+# keystrokes with events in specific contexts. Unlike style sheets however,
+# each selector can only be declared once.
+#
+# You can create a new keybinding in this file by typing "key" and then hitting
+# tab.
+#
+# Here's an example taken from Atom's built-in keymap:
+#
+# 'atom-text-editor':
+#   'enter': 'editor:newline'
+#
+# 'atom-workspace':
+#   'ctrl-shift-p': 'core:move-up'
+#   'ctrl-p': 'core:move-down'
+#
+# You can find more information about keymaps in these guides:
+# * http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings
+# * http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/
+#
+# If you're having trouble with your keybindings not working, try the
+# Keybinding Resolver: `Cmd+.` on macOS and `Ctrl+.` on other platforms. See the
+# Debugging Guide for more information:
+# * http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-the-keybindings
+#
+# This file uses CoffeeScript Object Notation (CSON).
+# If you are unfamiliar with CSON, you can read more about it in the
+# Atom Flight Manual:
+# http://flight-manual.atom.io/using-atom/sections/basic-customization/#configuring-with-cson
+
+'atom-workspace atom-pane, atom-workspace atom-text-editor:not(.mini)':
+  'ctrl-|': 'pane:split-right-and-copy-active-item'
+  'ctrl--': 'pane:split-down-and-copy-active-item'
+
+'atom-workspace, .command-palette atom-text-editor':
+  'cmd-p': 'command-palette:toggle'

--- a/spec/fixtures/keymaps/default-keymap.cson
+++ b/spec/fixtures/keymaps/default-keymap.cson
@@ -1,0 +1,32 @@
+# Your keymap
+#
+# Atom keymaps work similarly to style sheets. Just as style sheets use
+# selectors to apply styles to elements, Atom keymaps use selectors to associate
+# keystrokes with events in specific contexts. Unlike style sheets however,
+# each selector can only be declared once.
+#
+# You can create a new keybinding in this file by typing "key" and then hitting
+# tab.
+#
+# Here's an example taken from Atom's built-in keymap:
+#
+# 'atom-text-editor':
+#   'enter': 'editor:newline'
+#
+# 'atom-workspace':
+#   'ctrl-shift-p': 'core:move-up'
+#   'ctrl-p': 'core:move-down'
+#
+# You can find more information about keymaps in these guides:
+# * http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings
+# * http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/
+#
+# If you're having trouble with your keybindings not working, try the
+# Keybinding Resolver: `Cmd+.` on macOS and `Ctrl+.` on other platforms. See the
+# Debugging Guide for more information:
+# * http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-the-keybindings
+#
+# This file uses CoffeeScript Object Notation (CSON).
+# If you are unfamiliar with CSON, you can read more about it in the
+# Atom Flight Manual:
+# http://flight-manual.atom.io/using-atom/sections/basic-customization/#configuring-with-cson

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -588,6 +588,10 @@ describe('Metrics', async () => {
           })
         })
       })
+
+      afterEach(() => {
+        atom.keymaps.destroy()
+      })
     })
 
     describe('when no user-defined key bindings are present', () => {
@@ -620,6 +624,10 @@ describe('Metrics', async () => {
              eventObject.ev === 0
           })
         })
+      })
+
+      afterEach(() => {
+        atom.keymaps.destroy()
       })
     })
   })

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -9,7 +9,7 @@ const telemetry = require('telemetry-github')
 
 const store = new telemetry.StatsStore('atom', '1.2.3', true)
 
-describe('Metrics', async () => {
+describe('Metrics', () => {
   let workspaceElement = []
   const assertCommandNotReported = (commandName, additionalArgs) => {
     Reporter.request.reset()
@@ -476,7 +476,7 @@ describe('Metrics', async () => {
     })
   })
 
-  describe('reporting activation of optional packages', async () => {
+  describe('reporting activation of optional packages', () => {
     describe('when optional packages are present', () => {
       let originalPackageDirPaths = atom.packages.packageDirPaths
 
@@ -556,7 +556,7 @@ describe('Metrics', async () => {
     })
   })
 
-  describe('reporting presence of user-defined key bindings', async () => {
+  describe('reporting presence of user-defined key bindings', () => {
     describe('when user-defined key bindings are present', () => {
       it('reports the number of user-defined key bindings loaded at startup', async () => {
         await atom.packages.activatePackage('metrics')


### PR DESCRIPTION
### Description of the Change

Building on the effort kicked off in https://github.com/atom/metrics/pull/90, this pull request continues our quest to better understand the awareness and approachability of Atom's "hackability."

Atom's hackability comes in [multiple forms](https://flight-manual.atom.io/hacking-atom/), but for many users, custom keyboard shortcuts will be the first thing they look for. The Flight Manual describes the [steps for defining custom keyboard shortcuts](https://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings), but we don't currently have a way of knowing whether that translates into users actually setting up custom keyboard shortcuts. To assess the awareness and approachability of defining custom keyboard shortcuts, this pull request adds a metric to report the number of user-defined key bindings that are present.

Equipped with this information, we'll be able to assess the effectiveness of our efforts to increase the awareness and approachability of keyboard shortcut customization. For example, does describing custom keyboard shortcuts in the [welcome guide](https://github.com/atom/welcome) increase or decrease the percentage of users that define custom keyboard shortcuts?

Implementation-wise, this pull request sends an event that reports the quantity of user-defined key bindings that get loaded at Atom startup.

### Alternate Designs

Instead of reporting this metric at startup, we could report it each time a user adds, removes, or changes a user-defined key binding. Doing so would require that we subscribe to the [`did-reload-keymap`](https://github.com/atom/atom-keymap/blob/1cb3a7a7fb9b9cb1acd3d2f2234593abfe098015/src/keymap-manager.coffee#L190) event, in addition to the `did-load-user-keymap` event currently in use in this pull request. It's do-able, but the additional data doesn't seem worthwhile to justify the additional overhead and maintenance. And, we could always make this change later if we decide that it would be sufficiently useful. :innocent:

### Verification Process

- [x] Using an Atom installation that has no user-defined key bindings, verify that an event is recorded at startup reflecting that the instance has zero user-defined key bindings
- [x] Using an Atom installation that has some user-defined key bindings, verify that an event is recorded at startup reflecting the number of user-defined key bindings
