### PR TITLE
Add metric to help assess awareness of init script customizability

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -72,6 +72,7 @@ module.exports = {
 
     this.watchActivationOfOptionalPackages()
     this.watchLoadingOfUserDefinedKeyBindings()
+    this.watchUserInitScriptChanges()
     this.watchPaneItems()
     this.watchCommands()
     this.watchDeprecations()
@@ -138,6 +139,18 @@ module.exports = {
         null,
         userDefinedKeyBindings.length
       )
+    }))
+  },
+
+  watchUserInitScriptChanges () {
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      if (editor.getPath() === atom.getUserInitScriptPath()) {
+        const onDidSaveSubscription = editor.onDidSave(() =>
+          Reporter.sendEvent('customization', 'userInitScriptChanged')
+        )
+
+        this.subscriptions.add(editor.onDidDestroy(() => onDidSaveSubscription.dispose()))
+      }
     }))
   },
 

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
     "node-uuid": "~1.4.7",
-    "telemetry-github": "0.0.11",
-    "temp": "^0.8.3"
+    "telemetry-github": "0.0.11"
   },
   "devDependencies": {
-    "standard": "*"
+    "standard": "*",
+    "temp": "^0.8.3"
   },
   "standard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
     "node-uuid": "~1.4.7",
-    "telemetry-github": "0.0.11"
+    "telemetry-github": "0.0.11",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
     "standard": "*"


### PR DESCRIPTION
### Description of the Change

Building on the updates in https://github.com/atom/metrics/pull/90 and https://github.com/atom/metrics/pull/94, this pull request continues our quest to better understand the awareness and approachability of Atom's "hackability."

Atom's hackability comes in [multiple forms](https://flight-manual.atom.io/hacking-atom/), and the init script (i.e., `~/.atom/init.coffee` or `~/.atom/init.js`) is arguably the most powerful form of customizability, and it's a great sandbox for trying out customizations that could eventually graduate into a full-fledged package. The Flight Manual describes the [steps for customizing the init script](https://flight-manual.atom.io/hacking-atom/sections/the-init-file/), but we don't currently have a way of knowing whether that translates into users actually performing any customization. To assess the awareness and approachability of customizing the init script, this pull request adds a metric to report an event when the user changes their init script.

Equipped with this information, we'll be able to assess the effectiveness of our efforts to increase the awareness and approachability of init script customization. For example, does updating the [welcome guide's description of the init script](https://github.com/atom/welcome/blob/4f8dd926ed98c2102e9429018e66b6bb363ebc4f/lib/guide-view.js#L181-L206) increase or decrease the percentage of users that customize their init script?

### Design

Implementation-wise, this pull request watches for the user's init script to get opened in a TextEditor in Atom. Any time that TextEditor is saved, we record an event indicating that the user has changed their init script.

### Alternate Designs

- We could [use pathwatcher to watch for changes to the init script (ddcb6cdef7528f92a8b81fda71e4745f99e76d84). With that approach, as long as Atom is open, we would record an event any time the init script changes on disk, regardless of whether the user changed it in Atom or in another editor. However, if the user has multiple Atom windows open, we would record an event for _each_ open Atom window. :grimacing:
- At startup, we could compare the contents of the user's init script to the [default init script](https://github.com/atom/atom/blob/3938846f5e795210da5dbb11743509acca03aa79/dot-atom/init.coffee#L12). If the user's init script is different than the default init script, then we could report that the user has customized their init script. However, if we ever change the default `init.coffee`, this approach would wrongly conclude that an existing user has customized their init script when they have an unedited local copy of the old default init script. 🙈 
- We could attempt to detect the existence of _code_ in the init script as opposed to just detecting arbitrary changes to the init script. For example, we could try to detect new commands that get registered, new observers that get registered, etc. However, given that you can do almost anything in the init script, a user can make meaningful customizations that don't register commands, observers, etc. Therefore, any specific set of things we detect (e.g., commands, observers) will be an incomplete set of the possible customizations, so we won't have an accurate measure of which users have customized their init script. 😦 
- We could attempt to detect _usage_ of commands that were added in init script. Instead of simply detecting that a user customized their init script at some point in the past, this would be one way to measure that a user is _using_ those customizations. However, as noted in the previous bullet, commands are just one form of customization. If we only measure usage of custom commands, we wouldn't have an accurate measure of the number of users that are customizing their init script. 😕 

### Possible Drawbacks

- Measuring that the user saved their init script doesn't mean that they're _using_ the customizations they've made to their init script. For example, the user could add a command in their init script and then never use that command.
- The user could use a different editor to customize their Atom init script. If so, this implementation won't report that the user has customized their init script.
- If a user makes only trivial changes (e.g., whitespace changes) to their init script and then saves the file, this implementation will report that that the user has customized their init script, even though their edits haven't actually customized Atom's behavior.
- The current implementation records an event each time the init script is saved. If the user saves the file multiple times while making a single conceptual change, Atom will record multiple events (i.e., one event each time the script is saved).

### Verification Process

- [x] Verify that both `init.coffee` and `init.js` are supported
    - [x] Edit and save your `init.coffee` file, and verify that a `userInitScriptChanged` event is recorded
    - [x] Edit and save your `init.js` file, and verify that a `userInitScriptChanged` event is recorded
- [x] Verify that Windows paths and macOS/Linux paths are supported
    - [x] Edit and save your init script on macOS, and verify that a `userInitScriptChanged` event is recorded
    - [x] Edit and save your init script on Windows, and verify that a `userInitScriptChanged` event is recorded
- [x] Launch Atom with a custom home directory (e.g., `ATOM_HOME=/tmp/some-nonstandard-dir`), edit and save your init script, and verify that a `userInitScriptChanged` event is recorded

### TODO

- [x] Record event when init script changes
- [x] Document and execute verification process
