### PR TITLE
Add metric to help assess awareness of look-and-feel customizability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You will be asked at first-run whether you consent to telemetry being sent to th
 * Amount of time the app took to launch
 * Deprecated package names and versions
 * Chrome user-agent (version of Chrome, OS, CPU)
-* The number of non-core Atom packages that have been activated
+* The number of optional (non-bundled) Atom packages activated at startup
 
 This information is sent via [Google Analytics][GA] which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ You will be asked at first-run whether you consent to telemetry being sent to th
 * Deprecated package names and versions
 * Chrome user-agent (version of Chrome, OS, CPU)
 * The number of optional (non-bundled) Atom packages activated at startup
+* The number of [user-defined key bindings](https://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) loaded at startup
+* File save events when editing the [user init script](https://flight-manual.atom.io/hacking-atom/sections/the-init-file/)
+* File save events when editing the [user stylesheet](https://flight-manual.atom.io/using-atom/sections/basic-customization/#style-tweaks)
 
 This information is sent via [Google Analytics][GA] which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -73,6 +73,7 @@ module.exports = {
     this.watchActivationOfOptionalPackages()
     this.watchLoadingOfUserDefinedKeyBindings()
     this.watchUserInitScriptChanges()
+    this.watchUserStylesheetChanges()
     this.watchPaneItems()
     this.watchCommands()
     this.watchDeprecations()
@@ -147,6 +148,18 @@ module.exports = {
       if (editor.getPath() === atom.getUserInitScriptPath()) {
         const onDidSaveSubscription = editor.onDidSave(() =>
           Reporter.sendEvent('customization', 'userInitScriptChanged')
+        )
+
+        this.subscriptions.add(editor.onDidDestroy(() => onDidSaveSubscription.dispose()))
+      }
+    }))
+  },
+
+  watchUserStylesheetChanges () {
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      if (editor.getPath() === atom.styles.getUserStyleSheetPath()) {
+        const onDidSaveSubscription = editor.onDidSave(() =>
+          Reporter.sendEvent('customization', 'userStylesheetChanged')
         )
 
         this.subscriptions.add(editor.onDidDestroy(() => onDidSaveSubscription.dispose()))

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -628,6 +628,27 @@ describe('Metrics', () => {
     })
   })
 
+  describe('reporting customization of user stylesheet', () => {
+    it('reports event when stylesheet changes', async () => {
+      const tempDir = fs.realpathSync(temp.mkdirSync())
+      const userStylesheetPath = path.join(tempDir, 'styles.less')
+      fs.writeFileSync(userStylesheetPath, '')
+
+      spyOn(atom.styles, 'getUserStyleSheetPath').andReturn(userStylesheetPath)
+
+      await atom.packages.activatePackage('metrics')
+
+      const editor = await atom.workspace.open(userStylesheetPath)
+      editor.setText('atom-pane:not(.active) { opacity: 0.75; }')
+      editor.save()
+
+      await eventReportedPromise({
+        'category': 'customization',
+        'action': 'userStylesheetChanged'
+      })
+    })
+  })
+
   describe('when deactivated', async () =>
     it('stops reporting pane items', async () => {
       global.localStorage.setItem('metrics.userId', 'd')


### PR DESCRIPTION
### Description of the Change

In much the same way that #95 added a metric to better understand the awareness/approachability of customizing Atom via the user init script, this pull request adds a metric to better understand the awareness/approachability of customizing Atom's look-and-feel via the user stylesheet.

Implementation-wise, this pull request watches for the user's stylesheet to get opened in a `TextEditor` in Atom. Any time the `TextEditor` is saved, we record an event indicating that the user has changed their stylesheet.

### Alternate Designs

Essentially the same as the alternate designs described in #95, but applied to the user stylesheet instead of the user init script.

### Possible Drawbacks

Essentially the same potential drawbacks as those described in #95, but applied to the user stylesheet instead of the user init script.

### Verification Process

- [x] Verify that both [`styles.less` and `styles.css`](https://github.com/atom/atom/blob/8f7a55971eed347c9dcea0c2c057539f23c8ec67/src/style-manager.js#L253) are supported
    - [x] Edit and save your `styles.less` file, and verify that a `userStylesheetChanged` event is recorded
    - [x] Edit and save your `styles.css` file, and verify that a `userStylesheetChanged` event is recorded
- [x] Verify that Windows paths and macOS/Linux paths are supported
    - [x] Edit and save your user stylesheet on macOS, and verify that a `userStylesheetChanged` event is recorded
    - [x] Edit and save your user stylesheet on Windows, and verify that a `userStylesheetChanged` event is recorded
- [x] Launch Atom with a custom home directory (e.g., `ATOM_HOME=/tmp/some-nonstandard-dir`), edit and save your user stylesheet, and verify that a `userStylesheetChanged` event is recorded
