### PR TITLE
expose method for setting gitHubUser in stats store

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -36,7 +36,8 @@ module.exports = {
       sendEvent: Reporter.sendEvent.bind(Reporter),
       sendTiming: Reporter.sendTiming.bind(Reporter),
       addTiming: Reporter.addTiming.bind(Reporter),
-      sendException: Reporter.sendException.bind(Reporter)
+      sendException: Reporter.sendException.bind(Reporter),
+      setGitHubUser: Reporter.setGitHubUser.bind(Reporter)
     }
   },
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -126,6 +126,10 @@ class Reporter {
     this.send(params)
   }
 
+  static setGitHubUser(gitHubUser) {
+    this.getStore().setGitHubUser(gitHubUser);
+  }
+
   // Private
   static getStore () {
     if (!store) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "providedServices": {
     "metrics-reporter": {
       "versions": {
-        "1.1.0": "provideReporter"
+        "1.2.0": "provideReporter"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
     "node-uuid": "~1.4.7",
-    "telemetry-github": "0.0.11"
+    "telemetry-github": "0.0.12"
   },
   "devDependencies": {
     "standard": "*",

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -703,7 +703,7 @@ describe('Metrics', () => {
       })
     )
 
-    describe('::sendTiming', () =>
+    describe('::setGitHubUser', () =>
       it('sets the gitHubUser', () => {
         spyOn(store, 'setGitHubUser');
         const gitHubUser = 'beyonce'

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -703,6 +703,15 @@ describe('Metrics', () => {
       })
     )
 
+    describe('::sendTiming', () =>
+      it('sets the gitHubUser', () => {
+        spyOn(store, 'setGitHubUser');
+        const gitHubUser = 'beyonce'
+        reporterService.setGitHubUser(gitHubUser)
+        expect(store.setGitHubUser).toHaveBeenCalledWith(gitHubUser)
+      })
+    )
+
     describe('::sendException', () =>
       it('makes a request', () => {
         reporterService.sendException('desc')


### PR DESCRIPTION
## Description of the Change
In order to better understand how Atom fits in with GitHub workflows, add the ability to set the gitHubUser in the stats store. That username is then sent to GitHub's internal analytics pipeline along with the daily metrics dump.  

The `metrics` package doesn't know your GitHub username, nor should it.  So, this pull request exposes a method so that the GitHub package, which does know your GitHub username, can set it.

If a user doesn't use the GitHub package,  their username won't be sent.  And that's a good thing. Atom users are not, and should not be, required to use GitHub.  Metrics collection will also continue to be opt-in: any users who don't want to send usage metrics can turn it off.

## Alternate Designs
We could send the authentication token instead of the gitHub username.  However, storing/sending tokens is always more risky in terms of potential security issues.

## Test Plan
- [x]  write a unit test to verify that `setGitHubUser` is called on the stats store as expected
- [ ] From the developer console, manually call `setGitHubUser`, then send a daily stats dump.  Verify that daily stats dump contains `gitHubUser` field as expected.