### PR TITLE
Add metric to help assess Atom's reach across various developer ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You will be asked at first-run whether you consent to telemetry being sent to th
 * The number of [user-defined key bindings](https://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings) loaded at startup
 * File save events when editing the [user init script](https://flight-manual.atom.io/hacking-atom/sections/the-init-file/)
 * File save events when editing the [user stylesheet](https://flight-manual.atom.io/using-atom/sections/basic-customization/#style-tweaks)
+* Repository open events and the hostname from the repository's URL (i.e., `github.com`, `bitbucket.org`, `gitlab.com`, `visualstudio.com`, `amazonaws.com` if the repository is hosted at one of these domains; otherwise, the hostname is anonymized as `other`)
 
 This information is sent via [Google Analytics][GA] which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -4,6 +4,7 @@ const path = require('path')
 const Reporter = require('./reporter')
 const fs = require('fs-plus')
 const grim = require('grim')
+const {getDomain} = require('./repository-helpers')
 
 const IgnoredCommands = {
   'vim-mode:move-up': true,
@@ -75,6 +76,7 @@ module.exports = {
     this.watchUserInitScriptChanges()
     this.watchUserStylesheetChanges()
     this.watchPaneItems()
+    this.watchRepositories()
     this.watchCommands()
     this.watchDeprecations()
 
@@ -172,6 +174,20 @@ module.exports = {
       if (!this.shouldIncludePanesAndCommands) return
 
       Reporter.sendPaneItem(item)
+    }))
+  },
+
+  watchRepositories () {
+    // TODO Once atom.project.observeRepositories ships to Atom's stable
+    // channel (likely in Atom 1.30), remove this guard, and update the atom
+    // engine version in package.json to the first Atom version that includes
+    // atom.project.observeRepositories
+    if (atom.project.observeRepositories == null) return
+
+    this.subscriptions.add(atom.project.observeRepositories((repository) => {
+      const domain = getDomain(repository.getOriginURL())
+      Reporter.addCustomEvent('repository', { action: 'open', domain })
+      Reporter.send({ t: 'event', ec: 'repository', ea: 'open', el: domain })
     }))
   },
 

--- a/lib/repository-helpers.js
+++ b/lib/repository-helpers.js
@@ -1,0 +1,17 @@
+const getDomain = function (gitURL) {
+  const patternsToDomains = [
+    [/(https:\/\/|@)github\.com/, 'github.com'],
+    [/(https:\/\/|@)gitlab\.com/, 'gitlab.com'],
+    [/(https:\/\/|@)bitbucket\.org/, 'bitbucket.org'],
+    [/(https:\/\/|@).*\.visualstudio\.com/, 'visualstudio.com'],
+    [/(https:\/\/|@)git-codecommit\..*\.amazonaws\.com/, 'amazonaws.com']
+  ]
+
+  for (let [pattern, domain] of patternsToDomains) {
+    if (pattern.test(gitURL)) return domain
+  }
+
+  return 'other'
+}
+
+module.exports = {getDomain}

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -91,12 +91,12 @@ describe('Metrics', () => {
   it('reports events', async () => {
     jasmine.useRealClock()
     await atom.packages.activatePackage('metrics')
-    await conditionPromise(() => Reporter.request.callCount === 2)
+    await conditionPromise(() => Reporter.request.callCount > 0)
 
     Reporter.request.reset()
     await atom.packages.deactivatePackage('metrics')
     await atom.packages.activatePackage('metrics')
-    await conditionPromise(() => Reporter.request.callCount === 3)
+    await conditionPromise(() => Reporter.request.callCount > 0)
 
     let url = Reporter.request.calls[0].args[0]
     expect(url).toBeDefined()

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -478,6 +478,7 @@ describe('Metrics', () => {
       })
 
       it('will not report pane items', async () => {
+        Reporter.addCustomEvent.reset()
         Reporter.sendEvent.reset()
         await atom.packages.emitter.emit('did-add-pane')
 

--- a/spec/repository-helpers-spec.js
+++ b/spec/repository-helpers-spec.js
@@ -1,0 +1,46 @@
+const {getDomain} = require('../lib/repository-helpers')
+
+describe('getDomain', () => {
+  it('detects whitelisted domains for HTTPS URLs', () => {
+    expect(getDomain('https://github.com/electron/node')).toBe('github.com')
+    expect(getDomain('https://gitlab.com/electron/node')).toBe('gitlab.com')
+    expect(getDomain('https://bitbucket.org/electron/node')).toBe('bitbucket.org')
+    expect(getDomain('https://foo.visualstudio.com/electron/node')).toBe('visualstudio.com')
+    expect(getDomain('https://git-codecommit.us-east-1.amazonaws.com/electron/node')).toBe('amazonaws.com')
+  })
+
+  it('returns "other" for non-whitelisted domain in HTTPS URLs', () => {
+    expect(getDomain('https://example.com/electron/node')).toBe('other')
+    expect(getDomain('https://localhost/electron/node')).toBe('other')
+  })
+
+  it('detects whitelisted domains for SSH URLs', () => {
+    expect(getDomain('git@github.com:electron/node.git')).toBe('github.com')
+    expect(getDomain('git@gitlab.com/electron/node')).toBe('gitlab.com')
+    expect(getDomain('git@bitbucket.org/electron/node')).toBe('bitbucket.org')
+    expect(getDomain('git@foo.visualstudio.com/electron/node')).toBe('visualstudio.com')
+    expect(getDomain('git@git-codecommit.us-east-1.amazonaws.com/electron/node')).toBe('amazonaws.com')
+  })
+
+  it('returns "other" for non-whitelisted domain in ssh:// URLs', () => {
+    expect(getDomain('git@example.com:electron/node.git')).toBe('other')
+    expect(getDomain('git@localhost:electron/node.git')).toBe('other')
+  })
+
+  it('returns "other" for local filesystem URLs', () => {
+    expect(getDomain('electron/node.git')).toBe('other')
+    expect(getDomain('/srv/git/node.git')).toBe('other')
+    expect(getDomain('file:///srv/git/node.git')).toBe('other')
+    expect(getDomain('file:///srv/git/github.com.git')).toBe('other')
+  })
+
+  it('detects whitelisted domains for oddball URLs', () => {
+    expect(getDomain('https://github.com/bitbucket.org/visualstudio.com.gitlab.com')).toBe('github.com')
+    expect(getDomain('https://bitbucket.org/github.com/visualstudio.com.gitlab.com')).toBe('bitbucket.org')
+  })
+
+  it('returns "other" for non-whitelisted domain in oddball URLs', () => {
+    expect(getDomain('🙀')).toBe('other')
+    expect(getDomain(null)).toBe('other')
+  })
+})


### PR DESCRIPTION
### Description of the Change

When a repository is opened in Atom, report a "repository open" event. If the repository is hosted at github.com, gitlab.com, bitbucket.org, visualstudio.com, or on AWS CodeCommit, then include that info in the event; otherwise, report the hosting provider as "other".

This enhancement depends on a new Atom API that allows you to observe each time a repository is opened in Atom (`atom.project.observeRepositories`). I'll open a pull request in atom/atom soon to add that new API. In the meantime, you can see the initial spike implementation at https://github.com/atom/atom/commit/59dadb2cc923e2cb25fd1730550c65b3a0aabde0.

Because that API is not yet present in Atom, the implementation in the pull request first checks to see if `atom.project.observeRepositories` exists (i.e., feature detection). If the API exists, it uses the API to provide the new metric describe above; otherwise, the new metric is not provided.

### Verification Process

- [x] Using a version of Atom that offers the `atom.project.observeRepositories` API:
    - [x] Open a new blank Atom window (i.e., no projects in the tree-view) and verify that a repository open event is *not* recorded
    - [x] Open a new Atom window with a root directory that is not a repository and verify that a repository open event is *not* recorded
    - [x] Open a new Atom window with a root directory that is a repository and verify that a repository open event is recorded
    - [x] Open a new Atom window with a root directory that is a subdirectory of a repository and verify that a repository open event is recorded
    - [x] In an existing Atom window, add a root directory that is not a repository and verify that a repository open event is *not* recorded
    - [x] In an existing Atom window, add a root directory that is a repository and verify that a repository open event is recorded
    - [x] In an existing Atom window, add a root directory that is a subdirectory of a repository and verify that a repository open event is recorded
    - [x] Add a root directory for a repository whose origin URL points to `github.com`, and verify that the recorded event specifies the domain as `github.com`
    - [x] Add a root directory for a repository whose origin URL points to `example.com`, and verify that the recorded event specifies the domain as `other`
    - [x] Add a root directory for a brand new repository with no remote URL, and verify that the recorded event specifies the domain as `other`
- [x] Using a version of Atom that does not offer the `atom.project.observeRepositories` API, add a root directory that is a repository and verify that a repository open event is *not* recorded and that no exceptions occur
