### PR TITLE
:arrow_up: `telemetry`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
     "node-uuid": "~1.4.7",
-    "telemetry-github": "0.0.11"
+    "telemetry-github": "0.0.13"
   },
   "devDependencies": {
     "standard": "*",


### PR DESCRIPTION
Our analysts were having trouble accessing some of the data that was sent through the analytics back end via `telemetry`.  Easiest fix is to rename a variable to what the back end expects.

Test plan
- ran unit tests for `metrics` package
- In dev mode verified that no errors appeared in the console, stats store appeared to be working, etc. 
<img width="1200" alt="screen shot 2018-08-14 at 2 22 18 pm" src="https://user-images.githubusercontent.com/3781742/44119518-57558494-9fce-11e8-805a-0c99a4063933.png">
