### PR TITLE
RIP Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ You will be asked at first-run whether you consent to telemetry being sent to th
 * File save events when editing the [user stylesheet](https://flight-manual.atom.io/using-atom/sections/basic-customization/#style-tweaks)
 * Repository open events and the hostname from the repository's URL (i.e., `github.com`, `bitbucket.org`, `gitlab.com`, `visualstudio.com`, `amazonaws.com` if the repository is hosted at one of these domains; otherwise, the hostname is anonymized as `other`)
 
-This information is sent to GitHub's internal analytics pipeline via the `telemetry` package which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
+This information is sent to GitHub's internal analytics pipeline via the [`telemetry`][Telemetry] package which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
 
 [Telemetry]: https://github.com/atom/telemetry

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ You will be asked at first-run whether you consent to telemetry being sent to th
 * File save events when editing the [user stylesheet](https://flight-manual.atom.io/using-atom/sections/basic-customization/#style-tweaks)
 * Repository open events and the hostname from the repository's URL (i.e., `github.com`, `bitbucket.org`, `gitlab.com`, `visualstudio.com`, `amazonaws.com` if the repository is hosted at one of these domains; otherwise, the hostname is anonymized as `other`)
 
-This information is sent via [Google Analytics][GA] which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
+This information is sent to GitHub's internal analytics pipeline via the `telemetry` package which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
 
-[GA]: http://www.google.com/analytics
-[RFC4122]: http://www.ietf.org/rfc/rfc4122.txt
+[Telemetry]: https://github.com/atom/telemetry

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ You will be asked at first-run whether you consent to telemetry being sent to th
 This information is sent to GitHub's internal analytics pipeline via the [`telemetry`][Telemetry] package which allows the Atom team to analyze usage patterns and errors in order to help improve Atom.
 
 [Telemetry]: https://github.com/atom/telemetry
+[RFC4122]: http://www.ietf.org/rfc/rfc4122.txt

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -17,7 +17,7 @@ module.exports = {
   activate ({sessionLength}) {
     this.subscriptions = new CompositeDisposable()
     this.shouldIncludePanesAndCommands = Math.random() < 0.05
-    this.ensureClientId(() => this.begin(sessionLength))
+    this.begin(sessionLength)
   },
 
   deactivate () {
@@ -89,30 +89,6 @@ module.exports = {
       // Wait until window is fully bootstrapped before sending the load time
       Reporter.sendTiming('core', 'load', atom.getWindowLoadTime())
     )
-  },
-
-  ensureClientId (callback) {
-    // Incorrectly previously called userId. It's actually a clientId (i.e. not across devices)
-    if (global.localStorage.getItem('metrics.userId')) {
-      callback()
-    } else if (atom.config.get('metrics.userId')) {
-      // legacy. Users who had the metrics id in their config file
-      global.localStorage.setItem('metrics.userId', atom.config.get('metrics.userId'))
-      callback()
-    } else {
-      this.createClientId((clientId) => {
-        global.localStorage.setItem('metrics.userId', clientId)
-        callback()
-      })
-    }
-  },
-
-  createClientId (callback) {
-    callback(require('node-uuid').v4())
-  },
-
-  getClientId () {
-    return global.localStorage.getItem('metrics.userId')
   },
 
   watchActivationOfOptionalPackages () {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -187,7 +187,6 @@ module.exports = {
     this.subscriptions.add(atom.project.observeRepositories((repository) => {
       const domain = getDomain(repository.getOriginURL())
       Reporter.addCustomEvent('repository', { action: 'open', domain })
-      Reporter.send({ t: 'event', ec: 'repository', ea: 'open', el: domain })
     }))
   },
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const querystring = require('querystring')
 const telemetry = require('telemetry-github')
 
 const extend = function (target, ...propertyMaps) {
@@ -10,12 +9,6 @@ const extend = function (target, ...propertyMaps) {
     }
   }
   return target
-}
-
-const post = function (url) {
-  const xhr = new XMLHttpRequest()
-  xhr.open('POST', url)
-  xhr.send(null)
 }
 
 const getReleaseChannel = function () {
@@ -66,30 +59,21 @@ class Reporter {
     if (value != null) { params.ev = value }
 
     this.addCustomEvent(category, params)
-    this.send(params)
   }
 
   // Deprecated: use addTiming instead.
   static sendTiming (category, name, value) {
-    const params = {
-      t: 'timing',
-      utc: category,
-      utv: name,
-      utt: value
-    }
-
     this.addTiming(name, value, {category})
-    this.send(params)
   }
 
   static sendException (description) {
+    const eventType = 'exception'
     const params = {
-      t: 'exception',
+      t: eventType,
       exd: description,
       exf: atom.inDevMode() ? '0' : '1'
     }
-
-    this.send(params)
+    this.addCustomEvent(eventType, params)
   }
 
   static sendPaneItem (item) {
@@ -105,7 +89,6 @@ class Reporter {
     }
 
     this.addCustomEvent(eventType, params)
-    this.send(params)
   }
 
   static sendCommand (commandName) {
@@ -123,7 +106,6 @@ class Reporter {
     }
 
     this.addCustomEvent(eventType, params)
-    this.send(params)
   }
 
   // Private
@@ -134,31 +116,6 @@ class Reporter {
       store.setOptOut(notOptedIn)
     }
     return store
-  }
-
-  // Private
-  static send (params) {
-    if (global.navigator.onLine) {
-      extend(params, {
-        v: 1,
-        aip: 1,
-        tid: 'UA-3769691-33',
-        cid: global.localStorage.getItem('metrics.userId'),
-        an: 'atom',
-        av: atom.getVersion()
-      })
-
-      if (this.consented()) extend(params, this.getEventMetadata())
-
-      if (this.consented() || this.isTelemetryConsentChoice(params)) {
-        this.request(`https://ssl.google-analytics.com/collect?${querystring.stringify(params)}`)
-      }
-    }
-  }
-
-  // Private
-  static request (url) {
-    post(url)
   }
 
   // Private

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
-    "node-uuid": "~1.4.7",
     "telemetry-github": "0.0.13"
   },
   "devDependencies": {

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -593,17 +593,18 @@ describe('Metrics', () => {
 
       const {mainModule} = await atom.packages.activatePackage('metrics')
       mainModule.shouldIncludePanesAndCommands = true
-      // await conditionPromise(() => Reporter.request.callCount > 0)
+      await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
 
       await atom.workspace.open('file1.txt')
-      //todo: make this actually test addCustomEvent
-      // await conditionPromise(() => Reporter.request.callCount > 0)
+      await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
 
       Reporter.sendPaneItem.reset()
+      Reporter.addCustomEvent.reset()
       await atom.packages.deactivatePackage('metrics')
       await atom.workspace.open('file2.txt')
 
       expect(Reporter.sendPaneItem.callCount).toBe(0)
+      expect(Reporter.addCustomEvent.callCount).toBe(0)
     })
   )
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -23,7 +23,7 @@ describe('Metrics', () => {
   }
 
     const eventReportedPromise = ({category, action, value}) => {
-    const telemetryPromise = conditionPromise(() => {
+    return conditionPromise(() => {
       return Reporter.addCustomEvent.calls.find((call) => {
         const eventType = call.args[0]
         const eventObject = call.args[1]
@@ -33,8 +33,6 @@ describe('Metrics', () => {
           eventObject.ev === value
       })
     })
-    // clean this up - we probably don't need Promise.all here
-    return Promise.all([telemetryPromise])
   }
 
   beforeEach(() => {
@@ -444,7 +442,7 @@ describe('Metrics', () => {
       const repositoryPath = path.join(__dirname, '..')
       atom.project.addPath(repositoryPath)
 
-      const telemetryPromise = conditionPromise(() => {
+      await conditionPromise(() => {
         return Reporter.addCustomEvent.calls.find((call) => {
           const eventType = call.args[0]
           const eventObject = call.args[1]
@@ -453,8 +451,6 @@ describe('Metrics', () => {
             eventObject.domain === 'github.com'
         })
       })
-
-      await Promise.all([telemetryPromise])
     })
   })
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -17,12 +17,11 @@ describe('Metrics', () => {
   let workspaceElement = []
 
   const assertCommandNotReported = (commandName, additionalArgs) => {
-
     atom.commands.dispatch(workspaceElement, commandName, additionalArgs)
     expect(Reporter.addCustomEvent).not.toHaveBeenCalled()
   }
 
-    const eventReportedPromise = ({category, action, value}) => {
+  const eventReportedPromise = ({category, action, value}) => {
     return conditionPromise(() => {
       return Reporter.addCustomEvent.calls.find((call) => {
         const eventType = call.args[0]
@@ -261,7 +260,7 @@ describe('Metrics', () => {
   })
 
   describe('reporting exceptions', async () => {
-    const assertException = function(args, expectedMessage) {
+    const assertException = function (args, expectedMessage) {
       expect(args[0]).toEqual('exception')
       const event = args[1]
       expect(event.exd).toContain(expectedMessage)
@@ -411,7 +410,7 @@ describe('Metrics', () => {
         const paneItemCalls = Reporter.addCustomEvent.calls.filter((call) => {
           const eventType = call.args[0]
           const event = call.args[1]
-          return eventType == 'appview' && event.cd && 'TextEditor'
+          return eventType === 'appview' && event.cd === 'TextEditor'
         })
         expect(paneItemCalls.length).toBe(1)
       })

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -617,14 +617,14 @@ describe('Metrics', () => {
     })
 
     describe('::sendEvent', () =>
-      it('makes a request', () => {
+      it('sends an event', () => {
         reporterService.sendEvent('cat', 'action', 'label')
-        // expect(Reporter.request).toHaveBeenCalled()
+        expect(Reporter.addCustomEvent).toHaveBeenCalled()
       })
     )
 
     describe('::addCustomEvent', () =>
-      it('adds a custom event', () => {
+      it('adds a custom event to the StatsStore', () => {
         spyOn(store, 'addCustomEvent')
         const args = ['yass queen!', { woo: 'hoo' }]
         reporterService.addCustomEvent(...args)
@@ -654,16 +654,16 @@ describe('Metrics', () => {
     )
 
     describe('::sendTiming', () =>
-      it('sends an event to telemetry', () => {
+      it('sends timing', () => {
         reporterService.sendEvent('cat', 'name')
-        // expect(Reporter.request).toHaveBeenCalled()
+        expect(Reporter.addCustomEvent).toHaveBeenCalled()
       })
     )
 
     describe('::sendException', () =>
-      it('sends an exception to telemetry', () => {
+      it('sends an exception', () => {
         reporterService.sendException('desc')
-        // expect(Reporter.request).toHaveBeenCalled()
+        expect(Reporter.addCustomEvent).toHaveBeenCalled()
       })
     )
   })

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -382,13 +382,12 @@ describe('Metrics', () => {
         const {mainModule} = await atom.packages.activatePackage('metrics')
 
         mainModule.shouldIncludePanesAndCommands = false
-
-        await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
       })
 
       it('will not report pane items', async () => {
         Reporter.addCustomEvent.reset()
         Reporter.sendEvent.reset()
+        Reporter.sendPaneItem.reset()
         await atom.packages.emitter.emit('did-add-pane')
 
         expect(Reporter.sendPaneItem.callCount).toBe(0)

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -384,7 +384,7 @@ describe('Metrics', () => {
 
         mainModule.shouldIncludePanesAndCommands = false
 
-        // await conditionPromise(() => Reporter.request.callCount > 0)
+        await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
       })
 
       it('will not report pane items', async () => {
@@ -403,17 +403,17 @@ describe('Metrics', () => {
         const {mainModule} = await atom.packages.activatePackage('metrics')
         mainModule.shouldIncludePanesAndCommands = true
 
-        // await conditionPromise(() => Reporter.request.callCount > 0)
         await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
       })
 
       it('will report pane items', async () => {
         await atom.workspace.open('file1.txt')
-        // const paneItemCalls = Reporter.request.calls.filter((call) => {
-        //   const url = call.args[0]
-        //   return url.includes('t=appview') && url.includes('cd=TextEditor')
-        // })
-        // expect(paneItemCalls.length).toBe(1)
+        const paneItemCalls = Reporter.addCustomEvent.calls.filter((call) => {
+          const eventType = call.args[0]
+          const event = call.args[1]
+          return eventType == 'appview' && event.cd && 'TextEditor'
+        })
+        expect(paneItemCalls.length).toBe(1)
       })
     })
   })

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -319,7 +319,7 @@ describe('Metrics', () => {
   describe('reporting deprecations', async () => {
     beforeEach(async () => {
       await atom.packages.activatePackage('metrics')
-      // await conditionPromise(() => Reporter.request.callCount > 0)
+      await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
     })
 
     it('reports a deprecation with metadata specified', async () => {
@@ -365,17 +365,12 @@ describe('Metrics', () => {
 
       jasmine.restoreDeprecationsSnapshot()
 
-      // await conditionPromise(() => Reporter.request.callCount > 0)
-      // await eventReportedPromise({
-      //   'category': 'deprecation',
-      //   'action': 'numberOptionalPackagesActivatedAtStartup',
-      //   'value': 'bad things are bad'
-      // })
-      // let url = Reporter.request.mostRecentCall.args[0]
-      // expect(url).toContain('t=event')
-      // expect(url).toContain('ec=deprecation')
-      // expect(url).toMatch(/ea=metrics%40[0-9]+\.[0-9]+\.[0-9]+/)
-      // expect(url).toContain('el=bad%20things%20are%20bad')
+      await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
+      const args = Reporter.addCustomEvent.mostRecentCall.args
+      expect(args[0]).toEqual('deprecation-v3')
+      const event = args[1]
+      expect(event.ec).toEqual('deprecation-v3')
+      expect(event.el).toEqual('bad things are bad')
     })
   })
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -17,24 +17,12 @@ describe('Metrics', () => {
   let workspaceElement = []
 
   const assertCommandNotReported = (commandName, additionalArgs) => {
-    Reporter.request.reset()
 
     atom.commands.dispatch(workspaceElement, commandName, additionalArgs)
-    expect(Reporter.request).not.toHaveBeenCalled()
     expect(Reporter.addCustomEvent).not.toHaveBeenCalled()
   }
 
-  const eventReportedPromise = ({category, action, value}) => {
-    const googleAnalyticsPromise = conditionPromise(() => {
-      return Reporter.request.calls.find((call) => {
-        const url = call.args[0]
-        return url.includes('t=event') &&
-          url.includes(`ec=${category}`) &&
-          url.includes(`ea=${action}`) &&
-          (url.includes(`ev=${value}`) || value == null)
-      })
-    })
-
+    const eventReportedPromise = ({category, action, value}) => {
     const telemetryPromise = conditionPromise(() => {
       return Reporter.addCustomEvent.calls.find((call) => {
         const eventType = call.args[0]
@@ -45,14 +33,13 @@ describe('Metrics', () => {
           eventObject.ev === value
       })
     })
-
-    return Promise.all([googleAnalyticsPromise, telemetryPromise])
+    // clean this up - we probably don't need Promise.all here
+    return Promise.all([telemetryPromise])
   }
 
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace)
 
-    spyOn(Reporter, 'request')
     spyOn(Reporter, 'addCustomEvent').andCallThrough()
     spyOn(Reporter, 'getStore').andCallFake(() => store)
 
@@ -88,38 +75,12 @@ describe('Metrics', () => {
     expect(store.setOptOut.mostRecentCall.args[0]).toEqual(false)
   })
 
-  it('reports events', async () => {
-    jasmine.useRealClock()
-    await atom.packages.activatePackage('metrics')
-    await conditionPromise(() => Reporter.request.callCount > 0)
-
-    Reporter.request.reset()
-    await atom.packages.deactivatePackage('metrics')
-    await atom.packages.activatePackage('metrics')
-    await conditionPromise(() => Reporter.request.callCount > 0)
-
-    let url = Reporter.request.calls[0].args[0]
-    expect(url).toBeDefined()
-  })
-
-  it('reports over SSL', async () => {
-    await atom.packages.activatePackage('metrics')
-    await conditionPromise(() => Reporter.request.callCount > 0)
-
-    let url = Reporter.request.mostRecentCall.args[0]
-    expect(url).toMatch(/^https:\/\/ssl.google-analytics.com\/collect\?/)
-  })
-
   describe('event metadata', async () => {
     beforeEach(() => {
       spyOn(store, 'addTiming')
     })
     const assertMetadataSent = async (expectedName, expectedValue) => {
       await atom.packages.activatePackage('metrics')
-
-      await conditionPromise(() => Reporter.request.callCount > 0)
-      const url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain(`${expectedName}=${expectedValue}`)
 
       await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
       let metadata = Reporter.addCustomEvent.mostRecentCall.args[1]
@@ -132,16 +93,6 @@ describe('Metrics', () => {
     it('reports actual processor architecture', async () => {
       const expectedArch = process.env.PROCESSOR_ARCHITEW6432 === 'AMD64' ? 'x64' : process.arch
       await assertMetadataSent('cd2', expectedArch)
-    })
-
-    it('specifies anonymization', async () => {
-      // it appears that aip is a value that only needs to be sent
-      // to Google Analytics, so no need to use the assertMetadataSent helper here.
-      await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
-
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('&aip=1&')
     })
 
     it('specifies screen resolution', async () => {
@@ -171,10 +122,6 @@ describe('Metrics', () => {
       spyOn(atom, 'getVersion').andReturn('1.0.2-dev-dedbeef')
 
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
-
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=dev')
       let event = Reporter.addCustomEvent.mostRecentCall.args[1]
       expect(event.aiid).toEqual('dev')
     })
@@ -183,10 +130,6 @@ describe('Metrics', () => {
       spyOn(atom, 'getVersion').andReturn('1.0.2-beta1')
 
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
-
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=beta')
       let event = Reporter.addCustomEvent.mostRecentCall.args[1]
       expect(event.aiid).toEqual('beta')
     })
@@ -195,10 +138,7 @@ describe('Metrics', () => {
       spyOn(atom, 'getVersion').andReturn('1.0.2')
 
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
 
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=stable')
       let event = Reporter.addCustomEvent.mostRecentCall.args[1]
       expect(event.aiid).toEqual('stable')
     })
@@ -207,10 +147,7 @@ describe('Metrics', () => {
       spyOn(atom, 'getVersion').andReturn('1.0.2-nightly55')
 
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
 
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=nightly')
       let event = Reporter.addCustomEvent.mostRecentCall.args[1]
       expect(event.aiid).toEqual('nightly')
     })
@@ -219,10 +156,7 @@ describe('Metrics', () => {
       spyOn(atom, 'getVersion').andReturn('1.0.2-sushi1')
 
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
 
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=sushi')
       let event = Reporter.addCustomEvent.mostRecentCall.args[1]
       expect(event.aiid).toEqual('sushi')
     })
@@ -231,10 +165,9 @@ describe('Metrics', () => {
       spyOn(atom, 'getVersion').andReturn('wat.0.2')
 
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
 
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('aiid=unrecognized')
+      let event = Reporter.addCustomEvent.mostRecentCall.args[1]
+      expect(event.aiid).toEqual('unrecognized')
     })
   })
 
@@ -243,7 +176,8 @@ describe('Metrics', () => {
       beforeEach(async () => {
         global.localStorage.setItem('metrics.userId', 'a')
         await atom.packages.activatePackage('metrics')
-        await conditionPromise(() => Reporter.request.callCount > 0)
+        // await conditionPromise(() => Reporter.request.callCount > 0)
+        await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
 
         const {mainModule} = atom.packages.getLoadedPackage('metrics')
         mainModule.shouldIncludePanesAndCommands = false
@@ -281,17 +215,9 @@ describe('Metrics', () => {
         expect(event.ea).toEqual('some-package')
         expect(event.el).toEqual('some-package:a-command')
 
-        let url = Reporter.request.mostRecentCall.args[0]
-        expect(url).toContain('ec=command')
-        expect(url).toContain('ea=some-package')
-        expect(url).toContain('el=some-package%3Aa-command')
-        expect(url).toContain('ev=1')
-
         atom.commands.dispatch(workspaceElement, command, null)
         expect(Reporter.commandCount[command]).toBe(2)
 
-        url = Reporter.request.mostRecentCall.args[0]
-        expect(url).toContain('ev=2')
         expect(Reporter.addCustomEvent.mostRecentCall.args[1].ev).toEqual(2)
       })
 
@@ -341,16 +267,18 @@ describe('Metrics', () => {
       spyOn(atom, 'openDevTools').andReturn(Promise.resolve())
       spyOn(atom, 'executeJavaScriptInDevTools')
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
+      // todo: make this actually test addCustomEvent
+      // await conditionPromise(() => Reporter.request.callCount > 0)
     })
 
     it('reports an exception with the correct type', () => {
       let message = "Uncaught TypeError: Cannot call method 'getScreenRow' of undefined"
       window.onerror(message, 'abc', 2, 3, {ok: true})
 
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('t=exception')
-      expect(url).toContain('exd=TypeError')
+      // todo: make this actually test addCustomEvent
+      // let url = Reporter.request.mostRecentCall.args[0]
+      // expect(url).toContain('t=exception')
+      // expect(url).toContain('exd=TypeError')
     })
 
     describe('when the message has no clear type', () =>
@@ -358,9 +286,9 @@ describe('Metrics', () => {
         let message = ''
         window.onerror(message, 2, 3, {ok: true})
 
-        let url = Reporter.request.mostRecentCall.args[0]
-        expect(url).toContain('t=exception')
-        expect(url).toContain('exd=Unknown')
+        // let url = Reporter.request.mostRecentCall.args[0]
+        // expect(url).toContain('t=exception')
+        // expect(url).toContain('exd=Unknown')
       })
     )
 
@@ -368,29 +296,29 @@ describe('Metrics', () => {
       it('strips unix paths surrounded in quotes', () => {
         let message = "Error: ENOENT, unlink '/Users/someuser/path/file.js'"
         window.onerror(message, 2, 3, {ok: true})
-        let url = Reporter.request.mostRecentCall.args[0]
-        expect(decodeURIComponent(url)).toContain('exd=Error: ENOENT, unlink <path>')
+        // let url = Reporter.request.mostRecentCall.args[0]
+        // expect(decodeURIComponent(url)).toContain('exd=Error: ENOENT, unlink <path>')
       })
 
       it('strips unix paths without quotes', () => {
         let message = 'Uncaught Error: spawn /Users/someuser.omg/path/file-09238_ABC-Final-Final.js ENOENT'
         window.onerror(message, 2, 3, {ok: true})
-        let url = Reporter.request.mostRecentCall.args[0]
-        expect(decodeURIComponent(url)).toContain('exd=Error: spawn <path> ENOENT')
+        // let url = Reporter.request.mostRecentCall.args[0]
+        // expect(decodeURIComponent(url)).toContain('exd=Error: spawn <path> ENOENT')
       })
 
       it('strips windows paths without quotes', () => {
         let message = 'Uncaught Error: spawn c:\\someuser.omg\\path\\file-09238_ABC-Fin%%$#()al-Final.js ENOENT'
         window.onerror(message, 2, 3, {ok: true})
-        let url = Reporter.request.mostRecentCall.args[0]
-        expect(decodeURIComponent(url)).toContain('exd=Error: spawn <path> ENOENT')
+        // let url = Reporter.request.mostRecentCall.args[0]
+        // expect(decodeURIComponent(url)).toContain('exd=Error: spawn <path> ENOENT')
       })
 
       it('strips windows paths surrounded in quotes', () => {
         let message = "Uncaught Error: EACCES 'c:\\someuser.omg\\path\\file-09238_ABC-Fin%%$#()al-Final.js'"
         window.onerror(message, 2, 3, {ok: true})
-        let url = Reporter.request.mostRecentCall.args[0]
-        expect(decodeURIComponent(url)).toContain('exd=Error: EACCES <path>')
+        // let url = Reporter.request.mostRecentCall.args[0]
+        // expect(decodeURIComponent(url)).toContain('exd=Error: EACCES <path>')
       })
     })
   })
@@ -398,23 +326,14 @@ describe('Metrics', () => {
   describe('reporting deprecations', async () => {
     beforeEach(async () => {
       await atom.packages.activatePackage('metrics')
-      await conditionPromise(() => Reporter.request.callCount > 0)
+      // await conditionPromise(() => Reporter.request.callCount > 0)
     })
 
     it('reports a deprecation with metadata specified', async () => {
-      Reporter.request.reset()
       jasmine.snapshotDeprecations()
       const deprecationMessage = 'bad things are bad'
       grim.deprecate(deprecationMessage, {packageName: 'somepackage'})
       jasmine.restoreDeprecationsSnapshot()
-
-      await conditionPromise(() => Reporter.request.callCount > 0)
-
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('t=event')
-      expect(url).toContain('ec=deprecation')
-      expect(url).toContain('ea=somepackage%40unknown')
-      expect(url).toContain('el=bad%20things%20are%20bad')
 
       await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
       const args = Reporter.addCustomEvent.mostRecentCall.args
@@ -428,7 +347,6 @@ describe('Metrics', () => {
     })
 
     it('reports a deprecation without metadata specified', async () => {
-      Reporter.request.reset()
       jasmine.snapshotDeprecations()
 
       let stack = [
@@ -454,13 +372,17 @@ describe('Metrics', () => {
 
       jasmine.restoreDeprecationsSnapshot()
 
-      await conditionPromise(() => Reporter.request.callCount > 0)
-
-      let url = Reporter.request.mostRecentCall.args[0]
-      expect(url).toContain('t=event')
-      expect(url).toContain('ec=deprecation')
-      expect(url).toMatch(/ea=metrics%40[0-9]+\.[0-9]+\.[0-9]+/)
-      expect(url).toContain('el=bad%20things%20are%20bad')
+      // await conditionPromise(() => Reporter.request.callCount > 0)
+      // await eventReportedPromise({
+      //   'category': 'deprecation',
+      //   'action': 'numberOptionalPackagesActivatedAtStartup',
+      //   'value': 'bad things are bad'
+      // })
+      // let url = Reporter.request.mostRecentCall.args[0]
+      // expect(url).toContain('t=event')
+      // expect(url).toContain('ec=deprecation')
+      // expect(url).toMatch(/ea=metrics%40[0-9]+\.[0-9]+\.[0-9]+/)
+      // expect(url).toContain('el=bad%20things%20are%20bad')
     })
   })
 
@@ -474,7 +396,7 @@ describe('Metrics', () => {
 
         mainModule.shouldIncludePanesAndCommands = false
 
-        await conditionPromise(() => Reporter.request.callCount > 0)
+        // await conditionPromise(() => Reporter.request.callCount > 0)
       })
 
       it('will not report pane items', async () => {
@@ -493,17 +415,17 @@ describe('Metrics', () => {
         const {mainModule} = await atom.packages.activatePackage('metrics')
         mainModule.shouldIncludePanesAndCommands = true
 
-        await conditionPromise(() => Reporter.request.callCount > 0)
+        // await conditionPromise(() => Reporter.request.callCount > 0)
         await conditionPromise(() => Reporter.addCustomEvent.callCount > 0)
       })
 
       it('will report pane items', async () => {
         await atom.workspace.open('file1.txt')
-        const paneItemCalls = Reporter.request.calls.filter((call) => {
-          const url = call.args[0]
-          return url.includes('t=appview') && url.includes('cd=TextEditor')
-        })
-        expect(paneItemCalls.length).toBe(1)
+        // const paneItemCalls = Reporter.request.calls.filter((call) => {
+        //   const url = call.args[0]
+        //   return url.includes('t=appview') && url.includes('cd=TextEditor')
+        // })
+        // expect(paneItemCalls.length).toBe(1)
       })
     })
   })
@@ -518,7 +440,6 @@ describe('Metrics', () => {
 
       await atom.packages.activatePackage('metrics')
       Reporter.addCustomEvent.reset()
-      Reporter.request.reset()
 
       const repositoryPath = path.join(__dirname, '..')
       atom.project.addPath(repositoryPath)
@@ -533,17 +454,7 @@ describe('Metrics', () => {
         })
       })
 
-      const googleAnalyticsPromise = conditionPromise(() => {
-        return Reporter.request.calls.find((call) => {
-          const url = call.args[0]
-          return url.includes('t=event') &&
-            url.includes('ec=repository') &&
-            url.includes('ea=open') &&
-            url.includes('el=github.com')
-        })
-      })
-
-      await Promise.all([telemetryPromise, googleAnalyticsPromise])
+      await Promise.all([telemetryPromise])
     })
   })
 
@@ -696,10 +607,11 @@ describe('Metrics', () => {
 
       const {mainModule} = await atom.packages.activatePackage('metrics')
       mainModule.shouldIncludePanesAndCommands = true
-      await conditionPromise(() => Reporter.request.callCount > 0)
+      // await conditionPromise(() => Reporter.request.callCount > 0)
 
       await atom.workspace.open('file1.txt')
-      await conditionPromise(() => Reporter.request.callCount > 0)
+      //todo: make this actually test addCustomEvent
+      // await conditionPromise(() => Reporter.request.callCount > 0)
 
       Reporter.sendPaneItem.reset()
       await atom.packages.deactivatePackage('metrics')
@@ -715,15 +627,12 @@ describe('Metrics', () => {
       await atom.packages.activatePackage('metrics').then(pack => {
         reporterService = pack.mainModule.provideReporter()
       })
-
-      await conditionPromise(() => Reporter.request.callCount > 0)
-      Reporter.request.reset()
     })
 
     describe('::sendEvent', () =>
       it('makes a request', () => {
         reporterService.sendEvent('cat', 'action', 'label')
-        expect(Reporter.request).toHaveBeenCalled()
+        // expect(Reporter.request).toHaveBeenCalled()
       })
     )
 
@@ -758,16 +667,16 @@ describe('Metrics', () => {
     )
 
     describe('::sendTiming', () =>
-      it('makes a request', () => {
+      it('sends an event to telemetry', () => {
         reporterService.sendEvent('cat', 'name')
-        expect(Reporter.request).toHaveBeenCalled()
+        // expect(Reporter.request).toHaveBeenCalled()
       })
     )
 
     describe('::sendException', () =>
-      it('makes a request', () => {
+      it('sends an exception to telemetry', () => {
         reporterService.sendException('desc')
-        expect(Reporter.request).toHaveBeenCalled()
+        // expect(Reporter.request).toHaveBeenCalled()
       })
     )
   })


### PR DESCRIPTION
### Description of the Change

Previously, we migrated to send data to GitHub's analytics pipeline.  Then we validated the data we are sending to the internal pipeline against Google Analytics to cross check.  Everything looks good, so it's time to rip Google Analytics out entirely.

This pull request:
- Removes the `Reporter.post` and `Reporter.send` methods that make requests to Google Analytics.
- Rips out all references in unit tests to those methods
- Sends exceptions to GitHub's internal analytics pipeline, and adds unit tests to validate that the exception data is formatted the way we expect. 
- Rips out the code for generating client id / uuid.  `telemetry` handles setting the uuid already so `node-uuid` is no longer a necessary dependency.

### Alternate Designs

So we have a couple of methods that can send data to the stats store and eventually to GitHub's internal analytics pipeline:

`Reporter.sendEvent` (deprecated)
`Reporter.sendTiming` (deprecated)
`Reporter.addCustomEvent`
`Reported.addTiming`

I'd love to rip out `sendEvent` and `sendTiming` entirely.  But I found a few instances of community code that calls `consumeReporter` with older versions of the reporter interface:
https://github.com/search?q=consumeReporter&type=Code

Many of these are dotfiles repos, where users appear to have checked in their .atom file.  One of them appears to be a community package: https://github.com/ly1984119/cde-welcome

I chose to err on the more conservative side and avoid the possibility of breaking functionality for our users, even though it leaves this deprecated api cluttering our codebase.  If you disagree, let's talk - I'm entirely open to feedback.

I'm also not sure if sending the exceptions to GitHub's analytics pipeline is necessary.  Other GitHub apps (such as Desktop) are sending theirs, but Atom already uses BugSnag.  Do we really need the exceptions in both places?  It could be useful to, for example, compare exception rates of different applications.

### Benefits

The Atom community asked us not to send data to Google Analytics anymore and now we're not.  Plus, this cleans up a bunch of redundant code in our unit tests, and rips out a now-unncessary dependency.

### Possible Drawbacks
I can't think of any but I'm open to feedback, as always.

