### PR TITLE
:arrow_up: atom engine > 1.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/atom/metrics",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">1.30.0"
   },
   "providedServices": {
     "metrics-reporter": {

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -418,12 +418,6 @@ describe('Metrics', () => {
 
   describe('reporting repositories', () => {
     it('reports when a repository gets opened', async () => {
-      // TODO Once atom.project.observeRepositories ships to Atom's stable
-      // channel (likely in Atom 1.30), remove this guard, and update the atom
-      // engine version in package.json to the first Atom version that includes
-      // atom.project.observeRepositories
-      if (atom.project.observeRepositories == null) return
-
       await atom.packages.activatePackage('metrics')
       Reporter.addCustomEvent.reset()
 


### PR DESCRIPTION
### Description of the Change

In Atom 1.30.0, a new api was added to Atom to `observeRepositories` for a project.  That api is used in the `metrics` package.  Unit tests were written for the `metrics` package that depend on this new api being in place.  This pull request removes an if check in those unit tests so that the tests actually run, and upgrades the atom engine field in `package.json` to indicate that > 1.30.0 version is required.

### Alternate Designs

n/a

### Benefits

The unit tests will actually run and guard against future regressions.

### Possible Drawbacks

Can't think of any.

### Applicable Issues

n/a
