### PR TITLE
👕Pin linter to standard v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "telemetry-github": "0.0.13"
   },
   "devDependencies": {
-    "standard": "*",
+    "standard": "^11.0.1",
     "temp": "^0.8.3"
   },
   "standard": {


### PR DESCRIPTION
### Description of the Change

Prior to this change, this package depended on the latest version of `standard`. `standard` 12 was recently released, and it introduced several changes to the linter rules. As a result, the [latest commit](https://github.com/atom/metrics/commit/fd611bdf0528f278223b653c66d8cbfc3d4b67d8) on master [passed CI](https://travis-ci.org/atom/metrics/builds/419428902) when it was first pushed to this repository a month ago, but it [fails CI now](https://travis-ci.org/atom/metrics/builds/419429281) due to the changes in `standard` 12.

In https://github.com/atom/styleguide/pull/70#issuecomment-422128831, we decided to stick with the linter rules from `standard` 11 for now. Therefore, this pull request updates this package to depend on `standard` 11.

### Alternate Designs

See https://github.com/atom/styleguide/pull/70#issuecomment-422128831

### Benefits

Fixes CI. 

### Possible Drawbacks

See https://github.com/atom/styleguide/pull/70#issuecomment-422128831


