### PR TITLE
Add document with the events spec

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 * All new code requires tests to ensure against regressions
+* If you add/remove/modify any event please update the [documentation](docs/events.md)
 
 ### Description of the Change
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,6 +1,6 @@
 # Events specification
 
-This document all the data (and format) which gets send from Atom editor to the GitHub analytics pipeline.
+This document specifies all the data (along with the format) which gets send from the Atom editor core to the GitHub analytics pipeline. This does not include data that's logged by packages, like [the GitHub package](https://github.com/search?q=incrementCounter+repo%3Aatom%2Fgithub+path%3Alib&type=Code) or [the welcome package](https://github.com/search?q=sendEvent+repo%3Aatom%2Fwelcome+path%3Alib&type=Code).
 
 ## Type of events
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -30,21 +30,25 @@ Timing events log the duration that a specific action took plus some metadata th
 
 #### Window load time ([more info](https://atom.io/docs/api/v1.35.1/AtomEnvironment#instance-getWindowLoadTime))
 
-| field | value |
-|-------|------|
-| `eventType` | `core`
-| `metadata.t` | `event`
-| `metadata.ec` | `core`
-| `metadata.ea` | `load`
+* **eventType**: `core`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `core`
+  | `ea` | `load`
 
 #### Shell load time
 
-| field | value |
-|-------|------|
-| `eventType` | `shell`
-| `metadata.t` | `event`
-| `metadata.ec` | `shell`
-| `metadata.ea` | `load`
+* **eventType**: `shell`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `shell`
+  | `ea` | `load`
 
 ## Standard events
 
@@ -58,125 +62,148 @@ Standard events have a free form and can log any data in its `metadata` object. 
 
 #### Window start/end events
 
-| field | value |
-|-------|------|
-| `eventType` | `window`
-| `metadata.t` | `event`
-| `metadata.ec` | `window`
-| `metadata.ea` | `started`
+* **eventType**: `window`
+* **metadata**
 
-| field | value |
-|-------|------|
-| `eventType` | `window`
-| `metadata.t` | `event`
-| `metadata.ec` | `window`
-| `metadata.ea` | `ended`
-| `metadata.ev` | Session duration (in ms).
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `window`
+  | `ea` | `started`
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `window`
+  | `ea` | `ended`
+  | `ev` | Session duration (in ms).
 
 #### Open repository
 
-| field | value |
-|-------|------|
-| `eventType` | `repository`
-| `metadata.action` | `open`
-| `metadata.domain` | `github.com` \| `gitlab.com` \| `bitbucket.org` \| `visualstudio.com` \| `amazonaws.com` \| `other`
+* **eventType**: `repository`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `action` | `open`
+  | `domain` | `github.com` \| `gitlab.com` \| `bitbucket.org` \| `visualstudio.com` \| `amazonaws.com` \| `other`
 
 #### Open file
 
-| field | value |
-|-------|------|
-| `eventType` | `file`
-| `metadata.t` | `event`
-| `metadata.ec` | `file`
-| `metadata.ea` | `open`
-| `metadata.el` | `source.${grammarType}`
+* **eventType**: `file`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `file`
+  | `ea` | `open`
+  | `el` | `source.${grammarType}`
 
 #### Execute Atom command
 
-| field | value |
-|-------|------|
-| `eventType` | `command`
-| `metadata.t` | `event`
-| `metadata.ec` | `command`
-| `metadata.ea` | First part of the command (until the colon).
-| `metadata.el` | Executed command
-| `metadata.ev` | Number of times that command has been executed in this session.
+* **eventType**: `command`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `command`
+  | `ea` | First part of the command (until the colon).
+  | `el` | Executed command
+  | `ev` | Number of times that command has been executed in this session.
 
 #### Pane item added
 
-| field | value |
-|-------|------|
-| `eventType` | `appview`
-| `metadata.t` | `appview`
-| `metadata.cd` | Pane item name.
-| `metadata.dt` | Pane item grammar.
+* **eventType**: `appview`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `appview`
+  | `cd` | Pane item name.
+  | `dt` | Pane item grammar.
 
 #### Number of packages installed
 
-| field | value |
-|-------|------|
-| `eventType` | `package`
-| `metadata.t` | `event`
-| `metadata.ec` | `package`
-| `metadata.ea` | `numberOptionalPackagesActivatedAtStartup`
-| `metadata.ev` | The number of non-bundled active packages at startup.
+* **eventType**: `package`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `package`
+  | `ea` | `numberOptionalPackagesActivatedAtStartup`
+  | `ev` | The number of non-bundled active packages at startup.
 
 #### Number of custom keybindings
 
-| field | value |
-|-------|------|
-| `eventType` | `key-binding`
-| `metadata.t` | `event`
-| `metadata.ec` | `key-binding`
-| `metadata.ea` | `numberUserDefinedKeyBindingsLoadedAtStartup`
-| `metadata.ev` | The number of custom key bindings.
+* **eventType**: `key-binding`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `key-binding`
+  | `ea` | `numberUserDefinedKeyBindingsLoadedAtStartup`
+  | `ev` | The number of custom key bindings.
 
 #### Modify init script file
 
-| field | value |
-|-------|------|
-| `eventType` | `customization`
-| `metadata.t` | `event`
-| `metadata.ec` | `customization`
-| `metadata.ea` | `userInitScriptChanged`
+* **eventType**: `customization`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `customization`
+  | `ea` | `userInitScriptChanged`
 
 #### Modify user stylesheet
 
-| field | value |
-|-------|------|
-| `eventType` | `customization`
-| `metadata.t` | `event`
-| `metadata.ec` | `customization`
-| `metadata.ea` | `userStylesheetChanged`
+* **eventType**: `customization`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `customization`
+  | `ea` | `userStylesheetChanged`
 
 #### Metrics consents change
 
-| field | value |
-|-------|------|
-| `eventType` | `setting`
-| `metadata.t` | `event`
-| `metadata.ec` | `setting`
-| `metadata.ea` | `core.telemetryConsent`
-| `metadata.el` | `limited` \| `no`
+* **eventType**: `setting`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `setting`
+  | `ea` | `core.telemetryConsent`
+  | `el` | `limited` \| `no`
 
 #### Deprecation API usage
 
-| field | value |
-|-------|------|
-| `eventType` | `deprecation-v3`
-| `metadata.t` | `event`
-| `metadata.ec` | `deprecation-v3`
-| `metadata.ea` | `${packageName}@${version}` (e.g `settings@1.9.2`).
-| `metadata.el` | deprecation message.
+* **eventType**: `deprecation-v3`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `t` | `event`
+  | `ec` | `deprecation-v3`
+  | `ea` | `${packageName}@${version}` (e.g `settings@1.9.2`).
+  | `el` | deprecation message.
 
 #### Non-captured error
 
-| field | value |
-|-------|------|
-| `eventType` | `exception`
-| `metadata.t` | `exception`
-| `metadata.exd` | Exception stack trace.
-| `metadata.exf` | `0` | `1` (whether Atom is in Dev mode).
+* **eventType**: `exception`
+* **metadata**
+
+  | field | value |
+  |-------|------|
+  | `metadata.t` | `exception`
+  | `exd` | Exception stack trace.
+  | `exf` | `0` \| `1` (whether Atom is in Dev mode).
 
 ## Common metadata fields
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,193 @@
+# Events specification
+
+This document all the data (and format) which gets send from Atom editor to the GitHub analytics pipeline.
+
+## Type of events
+
+There are 3 different types of events:
+
+* **Counters**: Used to log the number of times a certain event happens. They don't contain any metadata or additional fields.
+* **Timing events**: Used to log duration of certain actions.
+* **Standard events**: Used to log any other action.
+
+## Counters
+
+These events are used to count how many times a certain action happens. They don't hold any metadata and they only log the name of the counter and the number of times it was incremented.
+
+Currently Atom core is not logging any counter event, but the [GitHub package](https://github.com/atom/github) is using counters to log things like the number of created PRs.
+
+## Timing events
+
+Timing events log the duration that a specific action took plus some metadata that depends on the event.
+
+| field | type | description |
+|-------|------|-------------|
+| `eventType` | `string` | Name of the event/action.
+| `date` | `string` | Date when the event happened (In [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)).
+| `durationInMilliseconds` | `number` | The time it took to perform the action.
+| `metadata` | `Object` | Any additional metadata.
+
+
+#### Window load time ([more info](https://atom.io/docs/api/v1.35.1/AtomEnvironment#instance-getWindowLoadTime))
+
+| field | value |
+|-------|------|
+| `eventType` | `core`
+| `metadata.t` | `event`
+| `metadata.ec` | `core`
+| `metadata.ea` | `load`
+
+#### Shell load time
+
+| field | value |
+|-------|------|
+| `eventType` | `shell`
+| `metadata.t` | `event`
+| `metadata.ec` | `shell`
+| `metadata.ea` | `load`
+
+## Standard events
+
+Standard events have a free form and can log any data in its `metadata` object. These are the most commonly used types of events.
+
+| field | type | description |
+|-------|------|-------------|
+| `eventType` | `string` | Name of the event/action.
+| `date` | `string` | Date when the event happened (In [ISO 8601](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)).
+| `metadata` | `Object` | Any additional metadata.
+
+#### Window start/end events
+
+| field | value |
+|-------|------|
+| `eventType` | `window`
+| `metadata.t` | `event`
+| `metadata.ec` | `window`
+| `metadata.ea` | `started`
+
+| field | value |
+|-------|------|
+| `eventType` | `window`
+| `metadata.t` | `event`
+| `metadata.ec` | `window`
+| `metadata.ea` | `ended`
+| `metadata.ev` | Session duration (in ms).
+
+#### Open repository
+
+| field | value |
+|-------|------|
+| `eventType` | `repository`
+| `metadata.action` | `open`
+| `metadata.domain` | `github.com` \| `gitlab.com` \| `bitbucket.org` \| `visualstudio.com` \| `amazonaws.com` \| `other`
+
+#### Open file
+
+| field | value |
+|-------|------|
+| `eventType` | `file`
+| `metadata.t` | `event`
+| `metadata.ec` | `file`
+| `metadata.ea` | `open`
+| `metadata.el` | `source.${grammarType}`
+
+#### Execute Atom command
+
+| field | value |
+|-------|------|
+| `eventType` | `command`
+| `metadata.t` | `event`
+| `metadata.ec` | `command`
+| `metadata.ea` | First part of the command (until the colon).
+| `metadata.el` | Executed command
+| `metadata.ev` | Number of times that command has been executed in this session.
+
+#### Pane item added
+
+| field | value |
+|-------|------|
+| `eventType` | `appview`
+| `metadata.t` | `appview`
+| `metadata.cd` | Pane item name.
+| `metadata.dt` | Pane item grammar.
+
+#### Number of packages installed
+
+| field | value |
+|-------|------|
+| `eventType` | `package`
+| `metadata.t` | `event`
+| `metadata.ec` | `package`
+| `metadata.ea` | `numberOptionalPackagesActivatedAtStartup`
+| `metadata.ev` | The number of non-bundled active packages at startup.
+
+#### Number of custom keybindings
+
+| field | value |
+|-------|------|
+| `eventType` | `key-binding`
+| `metadata.t` | `event`
+| `metadata.ec` | `key-binding`
+| `metadata.ea` | `numberUserDefinedKeyBindingsLoadedAtStartup`
+| `metadata.ev` | The number of custom key bindings.
+
+#### Modify init script file
+
+| field | value |
+|-------|------|
+| `eventType` | `customization`
+| `metadata.t` | `event`
+| `metadata.ec` | `customization`
+| `metadata.ea` | `userInitScriptChanged`
+
+#### Modify user stylesheet
+
+| field | value |
+|-------|------|
+| `eventType` | `customization`
+| `metadata.t` | `event`
+| `metadata.ec` | `customization`
+| `metadata.ea` | `userStylesheetChanged`
+
+#### Metrics consents change
+
+| field | value |
+|-------|------|
+| `eventType` | `setting`
+| `metadata.t` | `event`
+| `metadata.ec` | `setting`
+| `metadata.ea` | `core.telemetryConsent`
+| `metadata.el` | `limited` \| `no`
+
+#### Deprecation API usage
+
+| field | value |
+|-------|------|
+| `eventType` | `deprecation-v3`
+| `metadata.t` | `event`
+| `metadata.ec` | `deprecation-v3`
+| `metadata.ea` | `${packageName}@${version}` (e.g `settings@1.9.2`).
+| `metadata.el` | deprecation message.
+
+#### Non-captured error
+
+| field | value |
+|-------|------|
+| `eventType` | `exception`
+| `metadata.t` | `exception`
+| `metadata.exd` | Exception stack trace.
+| `metadata.exf` | `0` | `1` (whether Atom is in Dev mode).
+
+## Common metadata fields
+
+All the timing and the standard events contain some common metadata fields which get always logged:
+
+| field name | type | description |
+|---|---|---|
+| `cd2` | `string` | Processor architecture with correct detection of 64-Windows |
+| `cd3` | `string` | Processor architecture ([more info](https://nodejs.org/api/process.html#process_process_arch)) |
+| `cm1` | `number` | Size of used memory heap (in MiB).
+| `cm2` | `number` | Percentage of used heap (from 0-100).
+| `sr` | `string`  | Screen size in pixels (e.g `1024x768`).
+| `vp` | `string`  | Atom window size in pixels (e.g `400x300`).
+| `aiid` | `string`  | Release channel (`stable` \| `beta` \| `dev` \| `unrecognized`).


### PR DESCRIPTION
This PR adds a document which specifies all the data that gets logged by Atom core.

-------

**[Rendered version](https://github.com/atom/metrics/blob/add-events-doc/docs/events.md)**