### PR TITLE
Fix the payload of core timing events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -30,25 +30,21 @@ Timing events log the duration that a specific action took plus some metadata th
 
 #### Window load time ([more info](https://atom.io/docs/api/v1.35.1/AtomEnvironment#instance-getWindowLoadTime))
 
-* **eventType**: `core`
+* **eventType**: `load`
 * **metadata**
 
   | field | value |
   |-------|-------|
-  | `t` | `event`
   | `ec` | `core`
-  | `ea` | `load`
 
 #### Shell load time
 
-* **eventType**: `shell`
+* **eventType**: `load`
 * **metadata**
 
   | field | value |
   |-------|-------|
-  | `t` | `event`
   | `ec` | `shell`
-  | `ea` | `load`
 
 ## Standard events
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -82,12 +82,12 @@ module.exports = {
 
     if (atom.getLoadSettings().shellLoadTime != null) {
       // Only send shell load time for the first window
-      Reporter.sendTiming('shell', 'load', atom.getLoadSettings().shellLoadTime)
+      Reporter.addTiming('load', atom.getLoadSettings().shellLoadTime, { ec: 'shell' })
     }
 
     process.nextTick(() =>
       // Wait until window is fully bootstrapped before sending the load time
-      Reporter.sendTiming('core', 'load', atom.getWindowLoadTime())
+      Reporter.addTiming('load', atom.getWindowLoadTime(), { ec: 'core' })
     )
   },
 

--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -243,19 +243,14 @@ describe('Metrics', () => {
   describe('reporting timings', async () => {
     it('reports timing metrics', async () => {
       spyOn(Reporter, 'addTiming')
-      spyOn(Reporter, 'sendTiming').andCallThrough()
+
       await atom.packages.activatePackage('metrics')
       const expectedLoadTime = atom.getWindowLoadTime()
-
-      const sendTimingArgs = Reporter.sendTiming.mostRecentCall.args
-      expect(sendTimingArgs[0]).toEqual('core')
-      expect(sendTimingArgs[1]).toEqual('load')
-      expect(sendTimingArgs[2]).toEqual(expectedLoadTime)
 
       const addTimingArgs = Reporter.addTiming.mostRecentCall.args
       expect(addTimingArgs[0]).toEqual('load')
       expect(addTimingArgs[1]).toEqual(expectedLoadTime)
-      expect(addTimingArgs[2]).toEqual({category: 'core'})
+      expect(addTimingArgs[2]).toEqual({ec: 'core'})
     })
   })
 
@@ -648,13 +643,6 @@ describe('Metrics', () => {
         const args = [eventType, timingInMilliseconds, metadata]
         reporterService.addTiming(eventType, timingInMilliseconds, metadata)
         expect(store.addTiming).toHaveBeenCalledWith(...args)
-      })
-    )
-
-    describe('::sendTiming', () =>
-      it('sends timing', () => {
-        reporterService.sendEvent('cat', 'name')
-        expect(Reporter.addCustomEvent).toHaveBeenCalled()
       })
     )
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* If you add/remove/modify any event please update the [documentation](docs/events.md)

### Description of the Change

This PR changes the format of the `timing` events to send an `ec` field instead of a `category` field, which is more aligned with the rest of events.

### Alternate Designs

Leave it as it is 😄 

### Benefits

* Consistency
* Easier processing in our backends (we can reuse the processing for custom events).

### Possible Drawbacks

It's a change 😅 

### Applicable Issues

N/A

/cc @telliott27 
