### PR TITLE
Add config params to make debugging easier

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -111,7 +111,17 @@ class Reporter {
   // Private
   static getStore () {
     if (!store) {
-      store = new telemetry.StatsStore('atom', atom.getVersion(), atom.inDevMode())
+      store = new telemetry.StatsStore(
+        'atom',
+        atom.getVersion(),
+        atom.inDevMode(),
+        () => {},
+        {
+          logInDevMode: atom.config.get('metrics.dev.logInDevMode'),
+          reportingFrequency: atom.config.get('metrics.dev.reportingFrequency'),
+          verboseMode: atom.config.get('metrics.dev.verboseMode')
+        }
+      )
       const notOptedIn = atom.config.get('core.telemetryConsent') !== 'limited'
       store.setOptOut(notOptedIn)
     }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,36 @@
       "atom"
     ]
   },
+  "configSchema": {
+    "dev": {
+      "title": "Development Settings",
+      "description": "Please refresh the Atom window after modifying any setting in this section.",
+      "type": "object",
+      "properties": {
+        "verboseMode": {
+          "title": "Verbose mode",
+          "type": "boolean",
+          "default": false,
+          "description": "When set to `true`, any performed request containing metrics will be logged in console.",
+          "order": 1
+        },
+        "sendMetricsInDevMode": {
+          "title": "Send metrics in Dev mode",
+          "type": "boolean",
+          "default": false,
+          "description": "By default, Atom does not log anything in Dev mode. Set this param to `true` to log events in dev mode.",
+          "order": 2
+        },
+        "reportingFrequency": {
+          "title": "Reporting frequency",
+          "type": "number",
+          "default": 1440,
+          "description": "How often does Atom send metrics to GitHub (in minutes). By default it's once a day.",
+          "order": 3
+        }
+      }
+    }
+  },
   "scripts": {
     "lint": "standard --verbose",
     "test": "npm run lint && apm test"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
-    "telemetry-github": "0.0.13"
+    "telemetry-github": "0.0.14"
   },
   "devDependencies": {
     "standard": "^11.0.1",


### PR DESCRIPTION
### Description of the Change

This PR adds a few config params to the `metrics` package in Atom to make it easier to debug it:

<img width="788" alt="Screen Shot 2019-03-25 at 19 46 27" src="https://user-images.githubusercontent.com/408035/54945686-b41ae300-4f36-11e9-97cd-bb08774d10e1.png">

In order to properly work, this PR needs the functionality added in https://github.com/atom/telemetry/pull/24 .

### Test plan

- [x] Patch [this PR](https://github.com/atom/telemetry/pull/24) from `atom/telemetry` and verify that the 3 config params work correctly by looking at the developer tools and the network tab:
  - [x] `verboseMode` prints messages in the console.
  - [x] `reportingFrequency ` allows to control how often to send the metrics.
  - [x] `logInDevMode` sends network requests also in dev mode. It also prints them in the console (only in dev mode).

### Alternate Designs

N/A

### Benefits

Easier debugging.

### Possible Drawbacks

Developers may enable logging in dev mode and forget about it. To mitigate this, we enable the verbose mode when a user has logging in dev mode enabled.

### Applicable Issues

N/A
