### PR TITLE
Start logging startup markers

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -52,6 +52,19 @@ Timing events log the duration that a specific action took plus some metadata th
   |-------|-------|
   | `ec` | `shell`
 
+#### Startup markers
+
+We're logging a bunch of markers to understand where is the startup time spent in Atom.
+
+A list of all the markers can be found by using [GitHub search](https://github.com/atom/atom/search?q=StartupTime.addMarker%28&unscoped_q=StartupTime.addMarker%28).
+
+* **eventType**: `startup`
+* **metadata**
+
+  | field | value |
+  |-------|-------|
+  | `ec` | Label of the marker
+
 ## Standard events
 
 Standard events have a free form and can log any data in its `metadata` object. These are the most commonly used types of events.

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -85,10 +85,18 @@ module.exports = {
       Reporter.addTiming('load', atom.getLoadSettings().shellLoadTime, { ec: 'shell' })
     }
 
-    process.nextTick(() =>
+    process.nextTick(() => {
       // Wait until window is fully bootstrapped before sending the load time
       Reporter.addTiming('load', atom.getWindowLoadTime(), { ec: 'core' })
-    )
+
+      // atom.getStartupMarkers() is not available in the current Atom stable version
+      // so we need to check for it to make CI pass. This can be removed once v1.37
+      // is released.
+      const markers = atom.getStartupMarkers ? atom.getStartupMarkers() : []
+      for (const marker of markers) {
+        Reporter.addTiming('startup', marker.time, { ec: marker.label })
+      }
+    })
   },
 
   watchActivationOfOptionalPackages () {


### PR DESCRIPTION
### Description of the Change

This PR adds support to start logging startup markers via the Telemetry package by using an Atom API that is being added to Atom at the moment: https://github.com/atom/atom/pull/19297.

### Alternate Designs

N/A

### Benefits

More granular data to be able to identify bottlenecks in the startup time of Atom.

### Possible Drawbacks

We're logging much more measures which increases the payload sent via the internet connection of the user.

### Verification steps

Run Atom and enable the debug mode in the metrics package. Check that new metrics are being sent:

<img width="1013" alt="Screenshot 2019-05-10 at 17 32 08" src="https://user-images.githubusercontent.com/408035/57539347-98cf3000-734a-11e9-8188-cc0d354ca7f8.png">

### Applicable Issues

https://github.com/atom/atom/issues/13253
