### PR TITLE
Fix failing spec

### DIFF
--- a/spec/metrics-spec.js
+++ b/spec/metrics-spec.js
@@ -247,7 +247,7 @@ describe('Metrics', () => {
       await atom.packages.activatePackage('metrics')
       const expectedLoadTime = atom.getWindowLoadTime()
 
-      const addTimingArgs = Reporter.addTiming.mostRecentCall.args
+      const addTimingArgs = Reporter.addTiming.calls[0].args
       expect(addTimingArgs[0]).toEqual('load')
       expect(addTimingArgs[1]).toEqual(expectedLoadTime)
       expect(addTimingArgs[2]).toEqual({ec: 'core'})


### PR DESCRIPTION
This spec started to fail when trying to upgrade the metrics package in the atom repo: https://github.com/atom/atom/pull/19305