### PR TITLE
Retrieve user's keymap path only once

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -116,8 +116,9 @@ module.exports = {
 
   watchLoadingOfUserDefinedKeyBindings () {
     this.subscriptions.add(atom.keymaps.onDidLoadUserKeymap(() => {
+      const userKeymapPath = atom.keymaps.getUserKeymapPath()
       const userDefinedKeyBindings = atom.keymaps.getKeyBindings().filter((binding) => {
-        return binding.source === atom.keymaps.getUserKeymapPath()
+        return binding.source === userKeymapPath
       })
 
       Reporter.sendEvent(


### PR DESCRIPTION
Previously, we would retrieve all the active key bindings and filter out the ones that were not defined by the user. The filtering code would repeatedly call `atom.keymaps.getUserKeymapPath` for every loaded key binding, which had the unfortunate side effect of issuing a `statSync` call to check whether the custom keymap file existed or not.

<p align="center">
<img width="483" alt="Screen Shot 2019-05-30 at 11 51 09" src="https://user-images.githubusercontent.com/482957/58628715-c4ef2880-82da-11e9-84f3-5d69846e1120.png"></p>

This commit changes the package to only retrieve the user's keymap path once. This consistently reduces Atom startup time by ~50ms on my SSD. Since it was almost entirely I/O work, I would imagine this having an even more significant impact on HDDs.

<p align="center">
<img width="251" alt="Screen Shot 2019-05-30 at 11 50 38" src="https://user-images.githubusercontent.com/482957/58628723-c882af80-82da-11e9-945c-043332c53826.png"></p>