### PR TITLE
⬆️ telemetry@0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
-    "telemetry-github": "0.1.0"
+    "telemetry-github": "0.1.1"
   },
   "devDependencies": {
     "standard": "^11.0.1",


### PR DESCRIPTION
This new version includes a fallback for whenever the `IndexedDB` database cannot be opened to keep sending metrics.

----

*List of changes between `telemetry@0.1.0` and `telemetry@0.1.1`: https://github.com/atom/telemetry/compare/v0.1.0...v0.1.1*